### PR TITLE
Locale not set properly under Mac OS X 10.9 (Mavericks)

### DIFF
--- a/dabo/__init__.py
+++ b/dabo/__init__.py
@@ -16,7 +16,7 @@ from version import __version__
 dAppRef = None
 
 def getEncoding():
-	encoding = locale.getlocale()[1] or locale.getdefaultlocale()[1] or defaultEncoding
+	encoding = locale.getdefaultlocale()[1] or locale.getlocale()[1] or defaultEncoding
 
 	def _getEncodingName():
 		if encoding.isdigit():


### PR DESCRIPTION
A small change in  `dabo/__init__.py`: about the order the locale is being obtained. Not sure exactly why, but otherwise it would crash during run time under Mac OS X 10.9 (Mavericks).
