### PR TITLE
Finish Dabo3 migration to wxPhoenix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+.idea/*

--- a/dabo/biz/dBizobj.py
+++ b/dabo/biz/dBizobj.py
@@ -57,8 +57,7 @@ class dBizobj(dObject):
         # We need to make sure the cursor is created *before* the call to
         # initProperties()
         self._initProperties()
-        super(dBizobj, self).__init__(conn=conn, properties=properties, *args,
-                **kwargs)
+        super(dBizobj, self).__init__(properties=properties, *args, **kwargs)
         self._afterInit()
         self.__att_try_setFieldVal = True
 
@@ -295,8 +294,11 @@ class dBizobj(dObject):
             superMixin = main
             superCursor = secondary
             def __init__(self, *args, **kwargs):
-                super(cursorMix, self).__init__(*args, **kwargs)
-        return cursorMix
+                if hasattr(main, "__init__"):
+                    main.__init__(*(self,) + args, **kwargs)
+                if hasattr(secondary, "__init__"):
+                    secondary.__init__(*(self,) + args, **kwargs)
+        return    cursorMix
 
 
     def first(self):

--- a/dabo/dApp.py
+++ b/dabo/dApp.py
@@ -291,7 +291,8 @@ try again when it is running.
 
     def setup(self, initUI=True):
         """Set up the application object."""
-        from dabo import ui as dui
+        if initUI:
+            from dabo import ui as dui
         # dabo is going to want to import various things from the Home Directory
         if self.HomeDirectory not in sys.path:
             sys.path.append(self.HomeDirectory)
@@ -326,13 +327,8 @@ try again when it is running.
                 self.uiApp = dui.getUiApp(self, uiAppClass=None, callback=self.initUIApp, forceNew=True)
             else:
                 self.uiApp = dui.uiApp(self, callback=None)
-                self.initUIApp()
         else:
             self.uiApp = None
-
-#        from dabo.ui import controlClassImport
-#        dabo.ui.controls = controlClassImport
-
         # Flip the flag
         self._wasSetup = True
         # Call the afterSetup hook
@@ -375,7 +371,6 @@ try again when it is running.
 
     def start(self):
         """Start the application event loop."""
-        from dabo import ui as dui
         if not self._wasSetup:
             # Convenience; if you don't need to customize setup(), just
             # call start()
@@ -1248,14 +1243,13 @@ try again when it is running.
 
 
     def onHelpAbout(self, evt):
-        from dabo.ui.dDockForm import dDockForm
         about = self.AboutFormClass
         if about is None:
-            from dabo.ui.dialogs.htmlAbout import HtmlAbout as about
+            from dui.dialogs.htmlAbout import HtmlAbout as about
         frm = self.ActiveForm
         if frm is None:
             frm = self.MainForm
-        if frm.MDI or isinstance(frm, dDockForm):
+        if frm.MDI or isinstance(frm, dui.dDockForm):
             # Strange big sizing of the about form happens on Windows
             # when the parent form is MDI.
             frm = None
@@ -1374,11 +1368,10 @@ try again when it is running.
 
 
     def _getDefaultMenuBarClass(self):
-        from dabo.ui.dBaseMenuBar import dBaseMenuBar
         try:
             cls = self._defaultMenuBarClass
         except AttributeError:
-            cls = self._defaultMenuBarClass = dBaseMenuBar
+            cls = self._defaultMenuBarClass = dui.dBaseMenuBar
         return cls
 
     def _setDefaultMenuBarClass(self, val):
@@ -1491,8 +1484,8 @@ try again when it is running.
 
 
     def _getLoginDialogClass(self):
-        from dabo.ui.dialogs.login import Login
-        defaultDialogClass = Login
+        import dui.dialogs.login as login
+        defaultDialogClass = login.Login
         return getattr(self, "_loginDialogClass", defaultDialogClass)
 
     def _setLoginDialogClass(self, val):
@@ -1513,11 +1506,10 @@ try again when it is running.
 
 
     def _getMainFormClass(self):
-        from dabo.ui.dFormMain import dFormMain
         try:
             cls = self._mainFormClass
         except AttributeError:
-            cls = dFormMain
+            cls = dui.dFormMain
             self._mainFormClass = cls
         return cls
 

--- a/dabo/dApp.py
+++ b/dabo/dApp.py
@@ -171,8 +171,10 @@ class dApp(dObject):
 
 
     def __init__(self, selfStart=False, ignoreScriptDir=False, properties=None, *args, **kwargs):
-        if dabo.loadUserLocale:
-            locale.setlocale(locale.LC_ALL, '')
+        # Defer setting locale until the wx.App can do so (otherwise you can create a split-state between
+        # the OS and wx, which wx does not like.
+        #  if dabo.loadUserLocale:
+        #   locale.setlocale(locale.LC_ALL, '')
 
         # Some apps, such as the visual tools, are meant to be run from directories
         # other than that where they are located. In those cases, use the current dir.
@@ -379,7 +381,7 @@ try again when it is running.
         self._finished = False
         if (not self.SecurityManager or not self.SecurityManager.RequireAppLogin
                 or getattr(self, "_loggedIn", False) or self.SecurityManager.login()):
-            dui.callAfterInterval(5000, self._destroySplash)
+            dabo.ui.callAfterInterval(5000, self._destroySplash)
             self._retrieveMRUs()
             try:
                 self._loginDialog.Parent = None
@@ -1371,7 +1373,8 @@ try again when it is running.
         try:
             cls = self._defaultMenuBarClass
         except AttributeError:
-            cls = self._defaultMenuBarClass = dui.dBaseMenuBar
+            from dabo.ui.dBaseMenuBar import dBaseMenuBar
+            cls = self._defaultMenuBarClass = dBaseMenuBar
         return cls
 
     def _setDefaultMenuBarClass(self, val):

--- a/dabo/dApp.py
+++ b/dabo/dApp.py
@@ -36,7 +36,7 @@ class Collection(list):
     classes used in the app object.
     """
     def __init__(self):
-        super(Collection, self).__init__()
+        list.__init__(self)
 
 
     def add(self, objRef):
@@ -60,7 +60,6 @@ class TempFileHolder(object):
     deleted when the Python session ends.
     """
     def __init__(self):
-        super(TempFileHolder, self).__init__()
         self._tempFiles = []
 
 

--- a/dabo/dObject.py
+++ b/dabo/dObject.py
@@ -80,11 +80,12 @@ class dObject(PropertyHelperMixin, EventMixin):
             bad = ", ".join(["'%s'" % kk for kk in kwargs])
             raise TypeError("Invalid keyword arguments passed to %s: %s" % (self.__repr__(), bad))
 
-        PropertyHelperMixin.__init__(self)
-        EventMixin.__init__(self)
         if self._call_afterInit:
             self._afterInit()
         self.setProperties(properties)
+
+        PropertyHelperMixin.__init__(self)
+        EventMixin.__init__(self)
 
 
     def __repr__(self):

--- a/dabo/dObject.py
+++ b/dabo/dObject.py
@@ -24,8 +24,7 @@ class dObject(PropertyHelperMixin, EventMixin):
     _call_beforeInit, _call_afterInit, _call_initProperties = True, True, True
 
 
-    def __init__(self, parent=None, properties=None, attProperties=None, *args,
-            **kwargs):
+    def __init__(self, properties=None, attProperties=None, *args, **kwargs):
         if not hasattr(self, "_properties"):
             self._properties = {}
         if self._call_beforeInit:
@@ -79,14 +78,10 @@ class dObject(PropertyHelperMixin, EventMixin):
         if kwargs:
             # Some kwargs haven't been handled.
             bad = ", ".join(["'%s'" % kk for kk in kwargs])
-            # When we get the super() calls straightened out, we can change the
-            # back to an exception. For now, though, just print and move on.
-            # raise TypeError("Invalid keyword arguments passed to %s: %s" % (
-            #         self.__repr__(), bad))
-            print("Invalid keyword arguments passed to %s: %s" % (
-                    self.__repr__(), bad))
+            raise TypeError("Invalid keyword arguments passed to %s: %s" % (self.__repr__(), bad))
 
-        super(dObject, self).__init__(*args, **kwargs)
+        PropertyHelperMixin.__init__(self)
+        EventMixin.__init__(self)
         if self._call_afterInit:
             self._afterInit()
         self.setProperties(properties)
@@ -111,7 +106,7 @@ class dObject(PropertyHelperMixin, EventMixin):
 
         try:
             nm = self.Name
-        except (AttributeError, RuntimeError):
+        except AttributeError:
             nm = ""
 
         regid = getattr(self, "RegID", "")

--- a/dabo/db/dBackend.py
+++ b/dabo/db/dBackend.py
@@ -624,7 +624,7 @@ class dBackend(dObject):
 
         class WorkerThread(threading.Thread):
             def __init__(self, backendObj):
-                super(WorkerThread, self).__init__(self)
+                threading.Thread.__init__(self)
                 self._toStop = False
                 self.backendObj = backendObj
 

--- a/dabo/db/dConnection.py
+++ b/dabo/db/dConnection.py
@@ -10,7 +10,7 @@ class dConnection(dObject):
     def __init__(self, connectInfo=None, parent=None, forceCreate=False, **kwargs):
         self._baseClass = dConnection
         self._forceCreate = forceCreate
-        super(dConnection, self).__init__(**kwargs)
+        super(dConnection, self).__init__()
         # Store a reference to the parent object (bizobj maybe; app
         # object connection collection most likely)
         self.Parent = parent
@@ -62,9 +62,9 @@ class dConnection(dObject):
         class DaboCursor(dCursorMixin, cursorClass):
             superMixin = dCursorMixin
             superCursor = cursorClass
-            def __init__(self, connection=None, *args, **kwargs):
-                super(DaboCursor, self).__init__(sql="", connection=connection,
-                        *args, **kwargs)
+            def __init__(self, *args, **kwargs):
+                dCursorMixin.__init__(self, sql="", *args, **kwargs)
+                cursorClass.__init__(self, *args, **kwargs)
 
         bo = self.getBackendObject()
         crs = bo.getCursor(DaboCursor)
@@ -72,6 +72,7 @@ class dConnection(dObject):
         # Return the AuxCursor, as it skips some of the unnecessary
         # configuration and housekeeping
         return crs.AuxCursor
+
     cursor = getDaboCursor
 
 

--- a/dabo/db/dConnection.py
+++ b/dabo/db/dConnection.py
@@ -63,8 +63,11 @@ class dConnection(dObject):
             superMixin = dCursorMixin
             superCursor = cursorClass
             def __init__(self, *args, **kwargs):
-                dCursorMixin.__init__(self, sql="", *args, **kwargs)
-                cursorClass.__init__(self, *args, **kwargs)
+                for cls in (dCursorMixin, cursorClass):
+                    try:
+                        cls.__init__(*(self, ) + args, **kwargs)
+                    except AttributeError:
+                        pass
 
         bo = self.getBackendObject()
         crs = bo.getCursor(DaboCursor)

--- a/dabo/db/dCursorMixin.py
+++ b/dabo/db/dCursorMixin.py
@@ -27,10 +27,10 @@ class dCursorMixin(dObject):
     # Make these class attributes, so that they are shared among all instances
     _fieldStructure = {}
 
-    def __init__(self, sql=None, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         self._convertStrToUnicode = True
         self._initProperties()
-        sql = sql or ""
+        sql = kwargs.pop("sql", "")
         if sql and isinstance(sql, str) and len(sql) > 0:
             self.UserSQL = sql
         # Attributes used for M-M relationships
@@ -41,7 +41,12 @@ class dCursorMixin(dObject):
         self._assocPKColThis = None
         self._assocPKColOther = None
 
-        super(dCursorMixin, self).__init__(*args, **kwargs)
+        super(dCursorMixin, self).__init__()
+        ## pkm: Neither of the above are correct. We need to explicitly
+        ##      call dObject's __init__, otherwise the cursor object with
+        ##      which we are mixed-in will take the __init__.
+#        dObject.__init__(self, *args, **kwargs)
+#        super(dCursorMixin, self).__init__(*args, **kwargs)
 
         # Just in case this is used outside of the context of a bizobj
         if not hasattr(self, "superCursor") or self.superCursor is None:

--- a/dabo/db/dCursorMixin.py
+++ b/dabo/db/dCursorMixin.py
@@ -27,10 +27,9 @@ class dCursorMixin(dObject):
     # Make these class attributes, so that they are shared among all instances
     _fieldStructure = {}
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, sql="", *args, **kwargs):
         self._convertStrToUnicode = True
         self._initProperties()
-        sql = kwargs.pop("sql", "")
         if sql and isinstance(sql, str) and len(sql) > 0:
             self.UserSQL = sql
         # Attributes used for M-M relationships
@@ -41,12 +40,11 @@ class dCursorMixin(dObject):
         self._assocPKColThis = None
         self._assocPKColOther = None
 
-        super(dCursorMixin, self).__init__()
+        #super(dCursorMixin, self).__init__()
         ## pkm: Neither of the above are correct. We need to explicitly
         ##      call dObject's __init__, otherwise the cursor object with
         ##      which we are mixed-in will take the __init__.
-#        dObject.__init__(self, *args, **kwargs)
-#        super(dCursorMixin, self).__init__(*args, **kwargs)
+        dObject.__init__(self, *args, **kwargs)
 
         # Just in case this is used outside of the context of a bizobj
         if not hasattr(self, "superCursor") or self.superCursor is None:

--- a/dabo/db/dDataSet.py
+++ b/dabo/db/dDataSet.py
@@ -356,7 +356,7 @@ class dDataSet(tuple):
 
         class DictCursor(sqlite.Cursor):
             def __init__(self, *args, **kwargs):
-                super(DictCursor, self).__init__(*args, **kwargs)
+                sqlite.Cursor.__init__(self, *args, **kwargs)
                 self.row_factory = dict_factory
 
         if self._connection is None:

--- a/dabo/db/dbFirebird.py
+++ b/dabo/db/dbFirebird.py
@@ -17,7 +17,7 @@ class Firebird(dBackend):
     nameEnclosureChar = ""
 
     def __init__(self):
-        super(Firebird, self).__init__()
+        dBackend.__init__(self)
         self.dbModuleName = "kinterbasdb"
         self.fieldPat = re.compile("([A-Za-z_][A-Za-z0-9-_$]+)\.([A-Za-z_][A-Za-z0-9-_$]+)")
         self.paramPlaceholder = "?"

--- a/dabo/db/dbMsSQL.py
+++ b/dabo/db/dbMsSQL.py
@@ -9,7 +9,7 @@ from dabo.lib.utils import ustr
 class MSSQL(dBackend):
     """Class providing Microsoft SQL Server connectivity. Uses pymssql."""
     def __init__(self):
-        super(MSSQL, self).__init__()
+        dBackend.__init__(self)
         #- jfcs 11/06/06 first try getting Microsoft SQL 2000 server working
         # MSSQL requires the installation of FreeTDS.  FreeTDS can be downloaded from
         # http://www.freetds.org/

--- a/dabo/db/dbMySQL.py
+++ b/dabo/db/dbMySQL.py
@@ -26,7 +26,7 @@ class MySQL(dBackend):
     nameEnclosureChar = "`"
 
     def __init__(self):
-        super(MySQL, self).__init__()
+        dBackend.__init__(self)
         self.dbModuleName = "MySQLdb"
 
 

--- a/dabo/db/dbOracle.py
+++ b/dabo/db/dbOracle.py
@@ -14,7 +14,7 @@ from dabo.lib.utils import ustr
 class Oracle(dBackend):
     def __init__(self):
         import cx_Oracle as dbapi
-        super(Oracle, self).__init__()
+        dBackend.__init__(self)
         self.dbModuleName = "cx_Oracle"
         self.dbapi = dbapi
 

--- a/dabo/db/dbPostgreSQL.py
+++ b/dabo/db/dbPostgreSQL.py
@@ -60,7 +60,7 @@ class Postgres(dBackend):
 
     def __init__(self):
         """JFCS 08/23/07 Currently supporting only psycopg2"""
-        super(Postgres, self).__init__()
+        dBackend.__init__(self)
         self.dbModuleName = "psycopg"
         self.conn_user = ""
 

--- a/dabo/db/dbSQLite.py
+++ b/dabo/db/dbSQLite.py
@@ -24,8 +24,9 @@ def dict_factory(cursor, row):
 
 
 class DictCursor(dbapi.Cursor):
-    def __init__(self, connection=None, *args, **kwargs):
-        super(DictCursor, self).__init__(connection, *args, **kwargs)
+    def __init__(self, *args, **kwargs):
+#                dbapi.Cursor.__init__(self, *args, **kwargs)
+        super(DictCursor, self).__init__(*args, **kwargs)
         self.row_factory = dict_factory
 
 

--- a/dabo/db/dbSQLite.py
+++ b/dabo/db/dbSQLite.py
@@ -2,7 +2,6 @@
 import os
 import re
 import six
-import sqlite3 as dbapi
 import sys
 
 import dabo
@@ -14,42 +13,44 @@ from .dCursorMixin import dCursorMixin
 from dabo.lib.utils import ustr
 
 
-def dict_factory(cursor, row):
-    _types = getattr(cursor, "_types", {})
-    ret = {}
-    fieldNames = (fld[0] for fld in cursor.description)
-    for idx, field_name in enumerate(fieldNames):
-        ret[field_name] = row[idx]
-    return ret
-
-
-class DictCursor(dbapi.Cursor):
-    def __init__(self, *args, **kwargs):
-#                dbapi.Cursor.__init__(self, *args, **kwargs)
-        super(DictCursor, self).__init__(*args, **kwargs)
-        self.row_factory = dict_factory
-
-
-class DictConnection(dbapi.Connection):
-    def __init__(self, *args, **kwargs):
-        super(DictConnection, self).__init__(*args, **kwargs)
-
-    def cursor(self):
-        return DictCursor(self)
-
-
 class SQLite(dBackend):
-    """Class providing SQLite connectivity. Uses the sqlite3 package."""
+    """Class providing SQLite connectivity. Uses sqlite3 or pysqlite2 package."""
     def __init__(self):
-        super(SQLite, self).__init__()
-        self.dbModuleName = "sqlite3"
+        dBackend.__init__(self)
+        self.dbModuleName = "pysqlite2"
         self.paramPlaceholder = "?"
+        try:
+            from pysqlite2 import dbapi2 as dbapi
+        except ImportError:
+            import sqlite3 as dbapi
+        self.dbapi = dbapi
 
 
     def getConnection(self, connectInfo, forceCreate=False, **kwargs):
-        """Mods to sqlite to return DictCursors by default, so that dCursor
-        doesn't need to do the conversion.
-        """
+        ## Mods to sqlite to return DictCursors by default, so that dCursor doesn't
+        ## need to do the conversion:
+        dbapi = self.dbapi
+
+        def dict_factory(cursor, row):
+            _types = getattr(cursor, "_types", {})
+            ret = {}
+            fieldNames = (fld[0] for fld in cursor.description)
+            for idx, field_name in enumerate(fieldNames):
+                ret[field_name] = row[idx]
+            return ret
+
+        class DictCursor(self.dbapi.Cursor):
+            def __init__(self, *args, **kwargs):
+                dbapi.Cursor.__init__(self, *args, **kwargs)
+                self.row_factory = dict_factory
+
+        class DictConnection(self.dbapi.Connection):
+            def __init__(self, *args, **kwargs):
+                dbapi.Connection.__init__(self, *args, **kwargs)
+
+            def cursor(self):
+                return DictCursor(self)
+
         self._dictCursorClass = DictCursor
         pth = os.path.expanduser(connectInfo.Database)
         if not forceCreate and not dabo.createDbFiles and (pth != ":memory:"):
@@ -69,7 +70,7 @@ class SQLite(dBackend):
             pth = pth.decode(dabo.fileSystemEncoding)
 
         # Need to specify "isolation_level=None" to have transactions working correctly.
-        self._connection = dbapi.connect(pth, factory=DictConnection, isolation_level=None)
+        self._connection = self.dbapi.connect(pth, factory=DictConnection, isolation_level=None)
 
         # Non-utf8-encoded bytestrings could be in the database, and Dabo will try various encodings
         # to deal with it. So tell sqlite not to decode with utf-8, but to just return the bytes:
@@ -112,7 +113,7 @@ class SQLite(dBackend):
 
     def commitTransaction(self, cursor):
         """Commit a SQL transaction."""
-        opError = dbapi.OperationalError
+        opError = self.dbapi.OperationalError
         try:
             cursor.execute("COMMIT", errorClass=opError)
             dabo.dbActivityLog.info("SQL: commit")
@@ -142,7 +143,7 @@ class SQLite(dBackend):
 
 
     def formatBLOB(self, val):
-        return dbapi.Binary(val)
+        return self.dbapi.Binary(val)
 
 
     def formatDateTime(self, val):

--- a/dabo/db/dbTemplate.py
+++ b/dabo/db/dbTemplate.py
@@ -33,7 +33,7 @@ from dabo.lib.utils import ustr
 
 class NEWDATABASE(dBackend):
     def __init__(self):
-        super(NEWDATABASE, self).__init__()
+        dBackend.__init__(self)
         #### TODO: Customize with name of dbapi module
         self.dbModuleName = "???"
 

--- a/dabo/db/dbWeb.py
+++ b/dabo/db/dbWeb.py
@@ -11,7 +11,7 @@ from dabo.lib.RemoteConnector import RemoteConnector
 
 class Web(SQLite):
     def __init__(self):
-        super(Web, self).__init__()
+        SQLite.__init__(self)
         self.nameEnclosureChar = "~~"
         self._remoteConnector = RemoteConnector(self)
 

--- a/dabo/lib/DesignerClassConverter.py
+++ b/dabo/lib/DesignerClassConverter.py
@@ -1060,7 +1060,7 @@ def getControlClass(base):
             if hasattr(base, "__init__"):
                 apply(base.__init__,(self,) + args, kwargs)
             parent = self._extractKey(kwargs, "parent")
-            super(controlMix, self).__init__(parent, **kwargs)
+            cmix.__init__(self, parent, **kwargs)
             self.NameBase = ustr(self._baseClass).split(".")[-1].split("'")[0]
             self.BasePrefKey = prefkey
     return controlMix

--- a/dabo/lib/EasyDialogBuilder.py
+++ b/dabo/lib/EasyDialogBuilder.py
@@ -249,7 +249,7 @@ class fileButton(dui.dButton):
         self.format = format
         self.directory = directory
         self.target = target
-        super(fileButton, self).__init__(parent, properties=Properties)
+        dui.dButton.__init__(self, parent, properties=Properties)
 
     def afterInit(self):
         self.Caption = "Browse..."

--- a/dabo/lib/datanav/PageFrame.py
+++ b/dabo/lib/datanav/PageFrame.py
@@ -7,7 +7,7 @@ from dabo.dLocalize import _
 
 class PageFrameMixin(object):
     def __init__(self, parent, Name="PageFrame", *args, **kwargs):
-        super(PageFrameMixin, self).__init__(parent, Name=Name, *args, **kwargs)
+        self._pageStyleClass.__init__(self, parent, Name=Name, *args, **kwargs)
         # Add the images for the various pages.
         iconPath = "themes/tango/16x16"
         self.addImage("%s/actions/system-search.png" % iconPath, key="select")
@@ -81,6 +81,6 @@ def PageFrame(parent, tabStyle="tabs", *args, **kwargs):
     class DataNavPageFrame(PageFrameMixin, pageStyleClass):
         _pageStyleClass = property(lambda self: pageStyleClass)
         def __init__(*args, **kwargs):
-            super(DataNavPageFrame, self).__init__(*args, **kwargs)
+            PageFrameMixin.__init__(*args, **kwargs)
 
     return DataNavPageFrame(parent, *args, **kwargs)

--- a/dabo/lib/reportWriter.py
+++ b/dabo/lib/reportWriter.py
@@ -174,7 +174,7 @@ class PageCountCanvas(canvas.Canvas):
     Inspired by ActiveState recipe #576832 by Vinay Sajip.
     """
     def __init__(self, rw, *args, **kwargs):
-        super(PageCountCanvas, self).__init__(*args, **kwargs)
+        canvas.Canvas.__init__(self, *args, **kwargs)
         self.__rw = rw
         self.__saved_page_states = []
 

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -4,6 +4,7 @@ This is Dabo's user interface layer.
 """
 import datetime
 import glob
+import importlib
 import inspect
 import io
 import os
@@ -43,7 +44,7 @@ if "wx" not in sys.modules and not getattr(sys, "frozen", False):
 # Very first thing: check for proper wxPython build:
 _failedLibs = []
 # note: may need wx.animate as well
-for lib in ("wx", "wx.stc", "wx.lib.agw.foldpanelbar", "wx.gizmos",
+for lib in ("wx", "wx.adv", "wx.stc", "wx.lib.agw.foldpanelbar", "wx.gizmos",
         "wx.lib.calendar", "wx.lib.masked", "wx.lib.buttons"):
 
     if getattr(sys, "frozen", False):
@@ -87,7 +88,6 @@ uiType["platform"] = _platform
 # Add these to the dabo.ui namespace
 assertionException = wx.wxAssertionError
 nativeScrollBar = wx.ScrollBar
-
 
 def deadCheck(fn, *args, **kwargs):
     """
@@ -350,7 +350,7 @@ def callAfterInterval(interval, func, *args, **kwargs):
             pass
 
     _callAfterIntervalReferences[(func_ref, args)] = wx.CallLater(interval,
-            ca_func, func_ref, func, *args, **kwargs)
+                                                        ca_func, func_ref, func, *args, **kwargs)
 
 
 def setAfter(obj, prop, val):
@@ -458,6 +458,10 @@ def discontinueEvent(evt):
 
 
 def getEventData(wxEvt):
+    from dabo.ui.dMenu import dMenu
+    from dabo.ui.dTreeView import dTreeView
+    import wx.grid
+
     ed = {}
     eventType = wxEvt.GetEventType()
     if isinstance(wxEvt, wx._core.FocusEvent):
@@ -494,7 +498,7 @@ def getEventData(wxEvt):
             ed["mousePosition"] = wx.GetMousePosition()
 
     if isinstance(wxEvt, (wx.KeyEvent, wx.MouseEvent)):
-        ed["mousePosition"] = wxEvt.GetPositionTuple()
+        ed["mousePosition"] = wxEvt.GetPosition()
         ed["altDown"] = wxEvt.AltDown()
         ed["commandDown"] = wxEvt.CmdDown()
         ed["controlDown"] = wxEvt.ControlDown()
@@ -509,7 +513,7 @@ def getEventData(wxEvt):
                 pass
 
     if isinstance(wxEvt, wx.ListEvent):
-        pos = wxEvt.GetPosition()
+        pos = wxEvt.GetPoint()
         ht = obj.HitTest(pos)
         try:
             idx, flg = ht
@@ -551,7 +555,7 @@ def getEventData(wxEvt):
         ed["keyCode"] = wxEvt.GetKeyCode()
         ed["rawKeyCode"] = wxEvt.GetRawKeyCode()
         ed["rawKeyFlags"] = wxEvt.GetRawKeyFlags()
-        ed["unicodeChar"] = wxEvt.GetUniChar()
+        ed["unicodeChar"] = wxEvt.GetUnicodeKey()
         ed["unicodeKey"] = wxEvt.GetUnicodeKey()
         ed["hasModifiers"] = wxEvt.HasModifiers()
         try:
@@ -579,8 +583,8 @@ def getEventData(wxEvt):
     if isinstance(wxEvt, wx.CloseEvent):
         ed["force"] = not wxEvt.CanVeto()
 
-    if (isinstance(wxEvt, wx.TreeEvent) or isinstance(obj, dTreeView)) \
-            and not isinstance(wxEvt, wx.WindowDestroyEvent):
+    if (isinstance(wxEvt, (wx.TreeEvent, dTreeView))
+            and not isinstance(wxEvt, wx.WindowDestroyEvent)):
         sel = obj.Selection
         ed["selectedNode"] = sel
         if isinstance(sel, list):
@@ -648,7 +652,7 @@ def getEventData(wxEvt):
         except AttributeError:
             pass
 
-    if isinstance(wxEvt, wx.calendar.CalendarEvent):
+    if isinstance(wxEvt, wx.adv.CalendarEvent):
         ed["date"] = wxEvt.PyGetDate()
         # This will be undefined for all but the
         # EVT_CALENDAR_WEEKDAY_CLICKED event.
@@ -759,7 +763,7 @@ def getObjectAtPosition(x, y=None):
     if y is None:
         x, y = x
     win = wx.FindWindowAtPoint((x,y))
-    while not isinstance(win, dPemMixin):
+    while not isinstance(win, dabo.ui.dPemMixin.dPemMixin):
         try:
             win = win.GetParent()
         except AttributeError:
@@ -2061,5 +2065,4 @@ class GridSizerSpanException(dException):
     ColSpan of an item to an illegal value.
     """
     pass
-
 

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -43,7 +43,7 @@ if "wx" not in sys.modules and not getattr(sys, "frozen", False):
 # Very first thing: check for proper wxPython build:
 _failedLibs = []
 # note: may need wx.animate as well
-for lib in ("wx", "wx.adv", "wx.stc", "wx.lib.agw.foldpanelbar", "wx.gizmos",
+for lib in ("wx", "wx.stc", "wx.lib.agw.foldpanelbar", "wx.gizmos",
         "wx.lib.calendar", "wx.lib.masked", "wx.lib.buttons"):
 
     if getattr(sys, "frozen", False):
@@ -385,7 +385,6 @@ def callEvery(interval, func, *args, **kwargs):
     at the specified interval. Interval is given in milliseconds. It will pass along
     any additional arguments to the function when it is called.
     """
-    from dabo.ui.dTimer import dTimer
     def _onHit(evt):
         func(*args, **kwargs)
     ret = dTimer(Interval=interval)
@@ -459,8 +458,6 @@ def discontinueEvent(evt):
 
 
 def getEventData(wxEvt):
-    from dabo.ui.dMenu import dMenu
-    from dabo.ui.dTreeView import dTreeView
     ed = {}
     eventType = wxEvt.GetEventType()
     if isinstance(wxEvt, wx._core.FocusEvent):
@@ -497,7 +494,7 @@ def getEventData(wxEvt):
             ed["mousePosition"] = wx.GetMousePosition()
 
     if isinstance(wxEvt, (wx.KeyEvent, wx.MouseEvent)):
-        ed["mousePosition"] = wxEvt.GetPosition()
+        ed["mousePosition"] = wxEvt.GetPositionTuple()
         ed["altDown"] = wxEvt.AltDown()
         ed["commandDown"] = wxEvt.CmdDown()
         ed["controlDown"] = wxEvt.ControlDown()
@@ -512,7 +509,7 @@ def getEventData(wxEvt):
                 pass
 
     if isinstance(wxEvt, wx.ListEvent):
-        pos = wxEvt.GetPoint()
+        pos = wxEvt.GetPosition()
         ht = obj.HitTest(pos)
         try:
             idx, flg = ht
@@ -554,7 +551,7 @@ def getEventData(wxEvt):
         ed["keyCode"] = wxEvt.GetKeyCode()
         ed["rawKeyCode"] = wxEvt.GetRawKeyCode()
         ed["rawKeyFlags"] = wxEvt.GetRawKeyFlags()
-        ed["unicodeChar"] = wxEvt.GetUnicodeKey()
+        ed["unicodeChar"] = wxEvt.GetUniChar()
         ed["unicodeKey"] = wxEvt.GetUnicodeKey()
         ed["hasModifiers"] = wxEvt.HasModifiers()
         try:
@@ -582,8 +579,8 @@ def getEventData(wxEvt):
     if isinstance(wxEvt, wx.CloseEvent):
         ed["force"] = not wxEvt.CanVeto()
 
-    if (isinstance(wxEvt, (wx.TreeEvent, dTreeView))
-            and not isinstance(wxEvt, wx.WindowDestroyEvent)):
+    if (isinstance(wxEvt, wx.TreeEvent) or isinstance(obj, dTreeView)) \
+            and not isinstance(wxEvt, wx.WindowDestroyEvent):
         sel = obj.Selection
         ed["selectedNode"] = sel
         if isinstance(sel, list):
@@ -651,7 +648,7 @@ def getEventData(wxEvt):
         except AttributeError:
             pass
 
-    if isinstance(wxEvt, wx.adv.CalendarEvent):
+    if isinstance(wxEvt, wx.calendar.CalendarEvent):
         ed["date"] = wxEvt.PyGetDate()
         # This will be undefined for all but the
         # EVT_CALENDAR_WEEKDAY_CLICKED event.
@@ -759,7 +756,6 @@ def getObjectAtPosition(x, y=None):
     position, or None if there is no such object. You can pass separate
     x,y coordinates, or an x,y tuple.
     """
-    from dabo.ui.dPemMixin import dPemMixin
     if y is None:
         x, y = x
     win = wx.FindWindowAtPoint((x,y))
@@ -2065,3 +2061,5 @@ class GridSizerSpanException(dException):
     ColSpan of an item to an illegal value.
     """
     pass
+
+

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1393,19 +1393,17 @@ def createForm(srcFile, show=False, *args, **kwargs):
     return frm
 
 
-def createMenuBar(src, parent=None, previewFunc=None):
+def createMenuBar(src, form=None, previewFunc=None):
     """
-    Pass in either an .mnxml file path saved from the Menu Designer, or a dict
-    representing the menu, which will be used to instantiate a MenuBar. Returns
-    a reference to the newly-created MenuBar. You can optionally pass in a
-    reference to the form to which this menu is associated, so that you can
-    enter strings that represent form functions in the Designer, such as
-    'form.close', which will call the associated form's close() method. If
-    'previewFunc' is passed, the menu command that would have been eval'd and
-    executed on a live menu will instead be passed back as a parameter to that
-    function.
+    Pass in either an .mnxml file path saved from the Menu Designer, or a dict representing
+    the menu, which will be used to instantiate a MenuBar. Returns a reference to the
+    newly-created MenuBar. You can optionally pass in a reference to the form to which this menu
+    is associated, so that you can enter strings that represent form functions in the Designer,
+    such as 'form.close', which will call the associated form's close() method. If 'previewFunc'
+    is passed, the menu command that would have been eval'd and executed on a live menu will
+    instead be passed back as a parameter to that function.
     """
-    def addMenu(mb, parent, menuDict, previewFunc):
+    def addMenu(mb, menuDict, form, previewFunc):
         if form is None:
             form = dabo.dAppRef.ActiveForm
         if isinstance(mb, dabo.ui.dMenuBar.dMenuBar):
@@ -1429,7 +1427,7 @@ def createMenuBar(src, parent=None, previewFunc=None):
             if "Separator" in itm["name"]:
                 menu.appendSeparator()
             elif itm["name"] == "MenuPanel":
-                addMenu(menu, parent, itm, previewFunc)
+                addMenu(menu, itm, form, previewFunc)
             else:
                 itmatts = itm["attributes"]
                 cap = menu._extractKey(itmatts, "Caption")
@@ -1470,9 +1468,9 @@ def createMenuBar(src, parent=None, previewFunc=None):
                 stop(e, _("File Not Found"))
                 return
         mnd = dabo.lib.xmltodict.xmltodict(src)
-    mb = dabo.ui.dMenuBar.dMenuBar(parent=parent)
+    mb = dabo.ui.dMenuBar.dMenuBar()
     for mn in mnd["children"]:
-        addMenu(mb, parent, mn, previewFunc)
+        addMenu(mb, mn, form, previewFunc)
     return mb
 
 

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -312,11 +312,9 @@ def callAfter(fnc, *args, **kwargs):
     Call the passed function with the passed arguments in the next
     event loop.
     """
-    global lastCallAfterStack
     if dabo.saveCallAfterStack:
         lastCallAfterStack = "".join(traceback.format_stack())
     wx.CallAfter(fnc, *args, **kwargs)
-    print("CALL AFTER", fnc)
 
 
 _callAfterIntervalReferences = {}
@@ -331,10 +329,11 @@ def callAfterInterval(interval, func, *args, **kwargs):
     high.
     """
     global lastCallAfterStack
-    global _callAfterIntervalReferences
-
     if dabo.saveCallAfterStack:
         lastCallAfterStack = "".join(traceback.format_stack())
+    if isinstance(func, int):
+        # Arguments are in the old order
+        interval, func = func, interval
     func_ref = func
     if func.__closure__:
         func_ref = func.__code__
@@ -352,7 +351,6 @@ def callAfterInterval(interval, func, *args, **kwargs):
 
     _callAfterIntervalReferences[(func_ref, args)] = wx.CallLater(interval,
             ca_func, func_ref, func, *args, **kwargs)
-    print("CALL AFTER INTERVAL", interval, func)
 
 
 def setAfter(obj, prop, val):
@@ -363,7 +361,6 @@ def setAfter(obj, prop, val):
     try:
         fnc = getattr(obj.__class__, prop).fset
         wx.CallAfter(fnc, obj, val)
-        print("SET AFTER", obj, prop, val)
     except Exception as e:
         dabo.log.error(_("setAfter() failed to set property '%(prop)s' to value '%(val)s': %(e)s.")
                 % locals())
@@ -377,7 +374,6 @@ def setAfterInterval(interval, obj, prop, val):
     try:
         fnc = getattr(obj.__class__, prop).fset
         callAfterInterval(interval, fnc, obj, val)
-        print("SET AFTER INTERVAL", interval, obj, prop, val)
     except Exception as e:
         dabo.log.error(_("setAfterInterval() failed to set property '%(prop)s' to value '%(val)s': %(e)s.")
                 % locals())

--- a/dabo/ui/concordance.py
+++ b/dabo/ui/concordance.py
@@ -26,8 +26,8 @@ daboNames = list(dabo_to_wx.items())
 daboNames.sort()
 
 for k,v in dabo_to_wx.items():
-    preClasses = wx_to_dabo.setdefault(v, [])
-    preClasses.append(k)
+    wxClasses = wx_to_dabo.setdefault(v, [])
+    wxClasses.append(k)
 
 #wxNames = dict([[v,k] for k,v in dabo_to_wx.iteritems()]).items()
 wxNames = list(wx_to_dabo.items())

--- a/dabo/ui/dAutoComplete.py
+++ b/dabo/ui/dAutoComplete.py
@@ -60,8 +60,8 @@ def getSmallDnArrowImage():
 class myListCtrl(wx.ListCtrl, listmix.ListCtrlAutoWidthMixin):
     def __init__(self, parent, ID=-1, pos=wx.DefaultPosition,
             size=wx.DefaultSize, style=0):
-        super(myListCtrl, self).__init__(parent=parent, ID=ID, pos=pos,
-                size=size, style=style)
+        wx.ListCtrl.__init__(self, parent, ID, pos, size, style)
+        listmix.ListCtrlAutoWidthMixin.__init__(self)
 
 
 
@@ -80,6 +80,7 @@ class TextCtrlAutoComplete (wx.TextCtrl, listmix.ColumnSorterMixin):
             therest["style"]=wx.TE_PROCESS_ENTER | therest["style"]
         else:
             therest["style"]=wx.TE_PROCESS_ENTER
+        wx.TextCtrl.__init__(self, parent, **therest )
         #Some variables
         self._dropDownClick = dropDownClick
         self._colNames = colNames
@@ -107,17 +108,13 @@ class TextCtrlAutoComplete (wx.TextCtrl, listmix.ColumnSorterMixin):
         self.dropdownlistbox = myListCtrl( self.dropdown, style=flags,
                 pos=wx.Point( 0, 0) )
         #initialize the parent
-        if multiChoices:
-            ln = len(multiChoices)
-        else:
-            ln = 1
-        super(TextCtrlAutoComplete, self).__init__(parent, ln, **therest )
+        if multiChoices: ln = len(multiChoices)
+        else: ln = 1
+        #else: ln = len(choices)
+        listmix.ColumnSorterMixin.__init__(self, ln)
         #load the data
-        if multiChoices:
-            self.SetMultipleChoices(multiChoices, colSearch=colSearch,
-                    colFetch=colFetch)
-        else:
-            self.SetChoices(choices)
+        if multiChoices: self.SetMultipleChoices (multiChoices, colSearch=colSearch, colFetch=colFetch)
+        else: self.SetChoices ( choices )
         gp = self
         while gp != None :
             gp.Bind ( wx.EVT_MOVE , self.onControlChanged, gp )
@@ -453,9 +450,8 @@ class dAutoComplete(dControlMixin, TextCtrlAutoComplete):
         kwargs["choices"] = [""]
         self._userColNames = False
         self._dynamicChoices = None
-        super(dAutoComplete, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initEvents(self):

--- a/dabo/ui/dBaseMenuBar.py
+++ b/dabo/ui/dBaseMenuBar.py
@@ -41,7 +41,7 @@ class FileMenu(dMenu):
                     iconPath, HotKey="Ctrl+B", OnHit=app.onDebugWin,
                     ItemID="file_debugwin",
                     HelpText=_("Open up a debug output window"))
-            dabo.ui.setAfter(self.Parent.debugMenuItem, "Checked", True)
+            self.Parent.debugMenuItem.Checked = True
 
             self.Parent.inspectorMenuItem = self.append(_("Object &Inspector"), HotKey="Ctrl+Shift+I",
                     OnHit=app.onObjectInspectorWin, bmp="%s/apps/system-search.png" % iconPath,
@@ -185,6 +185,8 @@ class dBaseMenuBar(dMenuBar):
         self.viewMenu = self.appendMenu(ViewMenu(self, MenuID="base_view"))
         self.helpMenu = self.appendMenu(HelpMenu(self, MenuID="base_help"))
         super(dBaseMenuBar, self)._afterInit()
+        print(self.Children)
+
 
 
 if __name__ == "__main__":

--- a/dabo/ui/dBaseMenuBar.py
+++ b/dabo/ui/dBaseMenuBar.py
@@ -34,24 +34,23 @@ class FileMenu(dMenu):
             self.Parent.commandWinMenuItem = self.append(_("Command Win&dow"), HotKey="Ctrl+D",
                     OnHit=app.onCmdWin, bmp="%s/apps/utilities-terminal.png" % iconPath,
                     ItemID="file_commandwin",
-                    HelpText=_("Open up a command window for debugging"))
+                    help=_("Open up a command window for debugging"))
 
-            self.Parent.debugMenuItem = self.append(_("De&bug Output Window"),
-                    menutype="check", bmp="%s/apps/utilities-terminal.png" %
-                    iconPath, HotKey="Ctrl+B", OnHit=app.onDebugWin,
-                    ItemID="file_debugwin",
-                    HelpText=_("Open up a debug output window"))
+            self.Parent.debugMenuItem = self.append(_("De&bug Output Window"), menutype="check",
+                    bmp="%s/apps/utilities-terminal.png" % iconPath, HotKey="Ctrl+B",
+                    OnHit=app.onDebugWin, ItemID="file_debugwin",
+                    help=_("Open up a debug output window"))
             self.Parent.debugMenuItem.Checked = True
 
             self.Parent.inspectorMenuItem = self.append(_("Object &Inspector"), HotKey="Ctrl+Shift+I",
                     OnHit=app.onObjectInspectorWin, bmp="%s/apps/system-search.png" % iconPath,
                     ItemID="file_inspectorwin", menutype="check",
-                    HelpText=_("Open up the object inspector"))
+                    help=_("Open up the object inspector"))
 
         prmpt = _("Close Windo&w")
         self.Parent.closeWindowMenuItem = self.append(prmpt, HotKey="Ctrl+W", OnHit=app.onWinClose,
                 ItemID="file_close",
-                HelpText=_("Close the current window"))
+                help=_("Close the current window"))
 
         self.appendSeparator()
 
@@ -59,7 +58,7 @@ class FileMenu(dMenu):
         self.Parent.quitMenuItem = self.append(prmpt, HotKey="Ctrl+Q", id=wx.ID_EXIT, OnHit=app.onFileExit,
                 bmp="%s/actions/system-log-out.png" % iconPath,
                 ItemID="file_quit",
-                HelpText=_("Exit the application"))
+                help=_("Exit the application"))
 
 
 
@@ -72,34 +71,34 @@ class EditMenu(dMenu):
         self.Parent.undoMenuItem = self.append(_("&Undo"), HotKey="Ctrl+Z", OnHit=app.onEditUndo,
                 bmp="%s/actions/edit-undo.png" % iconPath,
                 ItemID="edit_undo",
-                HelpText=_("Undo last action"))
+                help=_("Undo last action"))
 
         self.Parent.redoMenuItem = self.append(_("&Redo"), HotKey="Ctrl+Shift+Z", OnHit=app.onEditRedo,
                 bmp="%s/actions/edit-redo.png" % iconPath,
                 ItemID="edit_redo",
-                HelpText=_("Undo last undo"))
+                help=_("Undo last undo"))
 
         self.appendSeparator()
 
         self.Parent.cutMenuItem = self.append(_("Cu&t"), HotKey="Ctrl+X", OnHit=app.onEditCut,
                 bmp="%s/actions/edit-cut.png" % iconPath,
                 ItemID="edit_cut",
-                HelpText=_("Cut selected text"))
+                help=_("Cut selected text"))
 
         self.Parent.copyMenuItem = self.append(_("&Copy"), HotKey="Ctrl+C", OnHit=app.onEditCopy,
                 bmp="%s/actions/edit-copy.png" % iconPath,
                 ItemID="edit_copy",
-                HelpText=_("Copy selected text"))
+                help=_("Copy selected text"))
 
         self.Parent.pasteMenuItem = self.append(_("&Paste"), HotKey="Ctrl+V", OnHit=app.onEditPaste,
                 bmp="%s/actions/edit-paste.png" % iconPath,
                 ItemID="edit_paste",
-                HelpText=_("Paste text from clipboard"))
+                help=_("Paste text from clipboard"))
 
         self.Parent.selectAllMenuItem = self.append(_("Select &All"), HotKey="Ctrl+A", OnHit=app.onEditSelectAll,
                 bmp="%s/actions/edit-select-all.png" % iconPath,
                 ItemID="edit_selectall",
-                HelpText=_("Select all text"))
+                help=_("Select all text"))
 
         self.appendSeparator()
 
@@ -108,18 +107,18 @@ class EditMenu(dMenu):
         self.Parent.findReplaceMenuItem = self.append(_("&Find / Replace"), HotKey="Ctrl+F", OnHit=app.onEditFind,
                 bmp="%s/actions/edit-find-replace.png" % iconPath,
                 ItemID="edit_findreplace",
-                HelpText=_("Find or Replace text in the active window"))
+                help=_("Find or Replace text in the active window"))
 
         self.Parent.findAgainMenuItem = self.append(_("Find A&gain"), HotKey="Ctrl+G", OnHit=app.onEditFindAgain, bmp="",
                 ItemID="edit_findagain",
-                HelpText=_("Repeat the last search"))
+                help=_("Repeat the last search"))
 
         self.appendSeparator()
 
         self.Parent.preferencesMenuItem = self.append(_("Pr&eferences"), OnHit=app.onEditPreferences,
                 bmp="%s/categories/preferences-system.png" % iconPath,
                 ItemID="edit_preferences",
-                HelpText=_("Set user preferences"), special="pref" )
+                help=_("Set user preferences"), special="pref" )
 
 
 
@@ -131,22 +130,22 @@ class ViewMenu(dMenu):
         self.Parent.increaseFontSizeMenuItem = self.append(_("Increase Font Size"),
                 HotKey="Ctrl++",
                 ItemID="view_zoomin", OnHit=app.fontZoomIn,
-                HelpText=_("Increase the font size"))
+                help=_("Increase the font size"))
         self.Parent.decreaseFontSizeMenuItem = self.append(_("Decrease Font Size"),
                 HotKey="Ctrl+-",
                 ItemID="view_zoomout", OnHit=app.fontZoomOut,
-                HelpText=_("Decrease the font size"))
+                help=_("Decrease the font size"))
         self.Parent.normalFontSizeMenuItem = self.append(_("Normal Font Size"),
                 HotKey="Ctrl+/",
                 ItemID="view_zoomnormal", OnHit=app.fontZoomNormal,
-                HelpText=_("Set font size to normal"))
+                help=_("Set font size to normal"))
 
         if app.ShowSizerLinesMenu:
             self.appendSeparator()
             self.Parent.sizerLinesMenuItem = self.append(_("Show/Hide Sizer &Lines"), HotKey="Ctrl+L",
                     OnHit=app.onShowSizerLines, menutype="check",
                     ItemID="view_showsizerlines",
-                    HelpText=_("Cool sizer visualizing feature; check it out!"))
+                    help=_("Cool sizer visualizing feature; check it out!"))
 
 
 class HelpMenu(dMenu):
@@ -163,15 +162,15 @@ class HelpMenu(dMenu):
         self.Parent.aboutMenuItem = self.append(caption, id=wx.ID_ABOUT,
                 OnHit=app.onHelpAbout,
                 ItemID="help_about",
-                HelpText=_("About this application"))
+                help=_("About this application"))
 
 
 class dBaseMenuBar(dMenuBar):
     """
-    Creates a basic menu bar with File, Edit, and HelpText menus.
+    Creates a basic menu bar with File, Edit, and Help menus.
 
-    The Edit menu has standard Copy, Cut, and Paste menu items, and the HelpText menu
-    has an About menu item. On Mac, the About menu item and HelpText menu are moved
+    The Edit menu has standard Copy, Cut, and Paste menu items, and the Help menu
+    has an About menu item. On Mac, the About menu item and Help menu are moved
     to the appropriate place in the application menu.
 
     Typical usage would be to instantiate dBaseMenuBar, set it to your form's

--- a/dabo/ui/dBaseMenuBar.py
+++ b/dabo/ui/dBaseMenuBar.py
@@ -127,6 +127,7 @@ class ViewMenu(dMenu):
         super(ViewMenu, self)._afterInit()
         app = self.Application
         self.Caption = _("&View")
+
         self.Parent.increaseFontSizeMenuItem = self.append(_("Increase Font Size"),
                 HotKey="Ctrl++",
                 ItemID="view_zoomin", OnHit=app.fontZoomIn,
@@ -184,14 +185,12 @@ class dBaseMenuBar(dMenuBar):
         self.viewMenu = self.appendMenu(ViewMenu(self, MenuID="base_view"))
         self.helpMenu = self.appendMenu(HelpMenu(self, MenuID="base_help"))
         super(dBaseMenuBar, self)._afterInit()
-        print(self.Children)
 
 
 
 if __name__ == "__main__":
     from dabo.dApp import dApp
-    from dabo.ui.dForm import dForm
     app = dApp()
-    app.DefaultMenuBarClass = dBaseMenuBar
-    app.MainFormClass = dForm
+    app.setup()
+    app.MainForm.MenuBar = dBaseMenuBar()
     app.start()

--- a/dabo/ui/dBitmap.py
+++ b/dabo/ui/dBitmap.py
@@ -14,7 +14,8 @@ class dBitmap(dControlMixin, dImageMixin, wx.StaticBitmap):
         preClass = wx.StaticBitmap
         picName = self._extractKey((kwargs, properties, attProperties), "Picture", "")
 
-        super(dBitmap, self).__init__(preClass, parent, properties=properties,
+        dImageMixin.__init__(self)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
         if picName:

--- a/dabo/ui/dBitmapButton.py
+++ b/dabo/ui/dBitmapButton.py
@@ -36,7 +36,8 @@ class dBitmapButton(dControlMixin, dImageMixin, wx.BitmapButton):
         # around the bitmap image in order for it to appear correctly
         self._bmpBorder = 10
 
-        super(dBitmapButton, self).__init__(preClass, parent, properties=properties,
+        dImageMixin.__init__(self)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dBitmapButton.py
+++ b/dabo/ui/dBitmapButton.py
@@ -24,7 +24,7 @@ class dBitmapButton(dControlMixin, dImageMixin, wx.BitmapButton):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBitmapButton
-        wxClass = wx.BitmapButton
+        preClass = wx.PreBitmapButton
         # Initialize the self._*picture attributes
         self._picture = self._downPicture = self._focusPicture = ""
         # These atts underlie the image sizing properties.
@@ -37,7 +37,7 @@ class dBitmapButton(dControlMixin, dImageMixin, wx.BitmapButton):
         self._bmpBorder = 10
 
         dImageMixin.__init__(self)
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dBitmapButton.py
+++ b/dabo/ui/dBitmapButton.py
@@ -24,7 +24,7 @@ class dBitmapButton(dControlMixin, dImageMixin, wx.BitmapButton):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBitmapButton
-        preClass = wx.PreBitmapButton
+        preClass = wx.BitmapButton
         # Initialize the self._*picture attributes
         self._picture = self._downPicture = self._focusPicture = ""
         # These atts underlie the image sizing properties.

--- a/dabo/ui/dBitmapButton.py
+++ b/dabo/ui/dBitmapButton.py
@@ -24,7 +24,7 @@ class dBitmapButton(dControlMixin, dImageMixin, wx.BitmapButton):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBitmapButton
-        preClass = wx.BitmapButton
+        wxClass = wx.BitmapButton
         # Initialize the self._*picture attributes
         self._picture = self._downPicture = self._focusPicture = ""
         # These atts underlie the image sizing properties.
@@ -37,7 +37,7 @@ class dBitmapButton(dControlMixin, dImageMixin, wx.BitmapButton):
         self._bmpBorder = 10
 
         dImageMixin.__init__(self)
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dBorderSizer.py
+++ b/dabo/ui/dBorderSizer.py
@@ -37,7 +37,7 @@ class dBorderSizer(dSizerMixin, wx.StaticBoxSizer):
             orientation = wx.VERTICAL
         else:
             orientation = wx.HORIZONTAL
-        super(dBorderSizer, self).__init__(box, orientation)
+        wx.StaticBoxSizer.__init__(self, box, orientation)
 
         self._properties = {}
         # The keyword properties can come from either, both, or none of:
@@ -170,8 +170,7 @@ class TestForm(dForm):
 
 class _dBorderSizer_test(dBorderSizer):
     def __init__(self, bx=None, *args, **kwargs):
-        super(_dBorderSizer_test, self).__init__(box=bx, orientation="h",
-                *args, **kwargs)
+        super(_dBorderSizer_test, self).__init__(box=bx, orientation="h", *args, **kwargs)
 
 
 

--- a/dabo/ui/dBorderlessButton.py
+++ b/dabo/ui/dBorderlessButton.py
@@ -43,9 +43,8 @@ class dBorderlessButton(dControlMixin, platebtn.PlateButton):
         # around the bitmap image in order for it to appear correctly
         self._bmpBorder = 10
 
-        super(dBorderlessButton, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initEvents(self):

--- a/dabo/ui/dBox.py
+++ b/dabo/ui/dBox.py
@@ -9,8 +9,8 @@ class dBox(dControlMixin, wx.StaticBox):
     ##      borders around panels and direct draw on any object. Opinions?
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBox
-        wxClass = wx.StaticBox
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreStaticBox
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dBox.py
+++ b/dabo/ui/dBox.py
@@ -10,7 +10,7 @@ class dBox(dControlMixin, wx.StaticBox):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBox
         preClass = wx.StaticBox
-        super(dBox, self).__init__(preClass, parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dBox.py
+++ b/dabo/ui/dBox.py
@@ -9,8 +9,8 @@ class dBox(dControlMixin, wx.StaticBox):
     ##      borders around panels and direct draw on any object. Opinions?
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBox
-        preClass = wx.StaticBox
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.StaticBox
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dBox.py
+++ b/dabo/ui/dBox.py
@@ -9,7 +9,7 @@ class dBox(dControlMixin, wx.StaticBox):
     ##      borders around panels and direct draw on any object. Opinions?
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dBox
-        preClass = wx.PreStaticBox
+        preClass = wx.StaticBox
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dButton.py
+++ b/dabo/ui/dButton.py
@@ -25,9 +25,8 @@ class dButton(dControlMixin, wx.Button):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dButton
         preClass = wx.Button
-        super(dButton, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initEvents(self):

--- a/dabo/ui/dButton.py
+++ b/dabo/ui/dButton.py
@@ -24,8 +24,8 @@ class dButton(dControlMixin, wx.Button):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dButton
-        preClass = wx.Button
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.Button
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dButton.py
+++ b/dabo/ui/dButton.py
@@ -24,7 +24,7 @@ class dButton(dControlMixin, wx.Button):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dButton
-        preClass = wx.PreButton
+        preClass = wx.Button
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dButton.py
+++ b/dabo/ui/dButton.py
@@ -24,8 +24,8 @@ class dButton(dControlMixin, wx.Button):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dButton
-        wxClass = wx.Button
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreButton
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dCalendar.py
+++ b/dabo/ui/dCalendar.py
@@ -38,9 +38,8 @@ class BaseCalendar(dControlMixin, wxcal):
         self._currentMonth = None
         self._currentYear = None
 
-        super(BaseCalendar, self).__init__(preClass, parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         # Store some event types in case we need to raise them
         self._setCalEventTypes()

--- a/dabo/ui/dCheckBox.py
+++ b/dabo/ui/dCheckBox.py
@@ -11,7 +11,7 @@ class dCheckBox(dDataControlMixin, wx.CheckBox):
     """Creates a checkbox, allowing editing boolean values."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dCheckBox
-        preClass = wx.PreCheckBox
+        preClass = wx.CheckBox
         dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dCheckBox.py
+++ b/dabo/ui/dCheckBox.py
@@ -11,8 +11,8 @@ class dCheckBox(dDataControlMixin, wx.CheckBox):
     """Creates a checkbox, allowing editing boolean values."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dCheckBox
-        preClass = wx.CheckBox
-        super(dCheckBox, self).__init__(preClass, parent, properties=properties,
+        wxClass = wx.CheckBox
+        super(dCheckBox, self).__init__(wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dCheckBox.py
+++ b/dabo/ui/dCheckBox.py
@@ -11,8 +11,8 @@ class dCheckBox(dDataControlMixin, wx.CheckBox):
     """Creates a checkbox, allowing editing boolean values."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dCheckBox
-        wxClass = wx.CheckBox
-        super(dCheckBox, self).__init__(wxClass, parent, properties=properties,
+        preClass = wx.PreCheckBox
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dCheckList.py
+++ b/dabo/ui/dCheckList.py
@@ -15,7 +15,7 @@ class dCheckList(dControlItemMixin, wx.CheckListBox):
         self._baseClass = dCheckList
         self._choices = []
         preClass = wx.CheckListBox
-        super(dCheckList, self).__init__(preClass, parent, properties=properties,
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dCheckList.py
+++ b/dabo/ui/dCheckList.py
@@ -14,8 +14,8 @@ class dCheckList(dControlItemMixin, wx.CheckListBox):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dCheckList
         self._choices = []
-        preClass = wx.CheckListBox
-        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.CheckListBox
+        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dCheckList.py
+++ b/dabo/ui/dCheckList.py
@@ -14,7 +14,7 @@ class dCheckList(dControlItemMixin, wx.CheckListBox):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dCheckList
         self._choices = []
-        preClass = wx.PreCheckListBox
+        preClass = wx.CheckListBox
         dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dCheckList.py
+++ b/dabo/ui/dCheckList.py
@@ -14,8 +14,8 @@ class dCheckList(dControlItemMixin, wx.CheckListBox):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dCheckList
         self._choices = []
-        wxClass = wx.CheckListBox
-        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreCheckListBox
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dCollapsiblePanel.py
+++ b/dabo/ui/dCollapsiblePanel.py
@@ -26,8 +26,7 @@ class dCollapsiblePanel(dControlMixin, pcp.PyCollapsiblePane):
         self.itemsCreated = False
         self._baseClass = dCollapsiblePanel
         preClass = pcp.PyCollapsiblePane
-        super(dCollapsiblePanel, self).__init__(preClass, parent, properties,
-                attProperties, *args, **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties, attProperties, *args, **kwargs)
         self._pPane = dPanel(self, Visible=False, BorderStyle="None")
 
     def _initEvents(self):

--- a/dabo/ui/dComboBox.py
+++ b/dabo/ui/dComboBox.py
@@ -29,7 +29,7 @@ class dComboBox(dControlItemMixin, wx.ComboBox):
         self._textToAppend = ""
 
         preClass = wx.ComboBox
-        super(dComboBox, self).__init__(preClass, parent, properties=properties,
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dComboBox.py
+++ b/dabo/ui/dComboBox.py
@@ -28,8 +28,8 @@ class dComboBox(dControlItemMixin, wx.ComboBox):
         # Holds the text to be appended
         self._textToAppend = ""
 
-        preClass = wx.ComboBox
-        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.ComboBox
+        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dComboBox.py
+++ b/dabo/ui/dComboBox.py
@@ -28,7 +28,7 @@ class dComboBox(dControlItemMixin, wx.ComboBox):
         # Holds the text to be appended
         self._textToAppend = ""
 
-        preClass = wx.PreComboBox
+        preClass = wx.ComboBox
         dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dComboBox.py
+++ b/dabo/ui/dComboBox.py
@@ -28,8 +28,8 @@ class dComboBox(dControlItemMixin, wx.ComboBox):
         # Holds the text to be appended
         self._textToAppend = ""
 
-        wxClass = wx.ComboBox
-        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreComboBox
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dControlItemMixin.py
+++ b/dabo/ui/dControlItemMixin.py
@@ -313,11 +313,10 @@ class dControlItemMixin(dDataControlMixin):
         return self._sortFunction
 
     def _setSortFunction(self, val):
-        from dabo.ui.dListControl import dListControl
         if self._constructed():
             if callable(val):
                 self._sortFunction = val
-                if not isinstance(self, dListControl):
+                if not isinstance(self, dui.dListControl):
                     # Force a re-ordering
                     self.sort()
             else:

--- a/dabo/ui/dDataControlMixin.py
+++ b/dabo/ui/dDataControlMixin.py
@@ -26,7 +26,7 @@ class dDataControlMixin(dControlMixin):
         self._inDataUpdate = False
         self._from_flushValue = False
 
-        super(dDataControlMixin, self).__init__(*args, **kwargs)
+        dControlMixin.__init__(self, *args, **kwargs)
 
         self._value = self.Value
         self._enabled = True
@@ -211,8 +211,7 @@ class dDataControlMixin(dControlMixin):
         ##- #if oldVal is None and curVal is None:
         ##-    # Could be changed and we just don't know it...
         ##- #    isChanged = True
-        from dabo.ui.dToggleButton import dToggleButton
-        if isinstance(self, dToggleButton):
+        if isinstance(self, dui.dToggleButton):
             # These classes change their value before the GotFocus event
             # can store the oldval, so always flush 'em.
             oldVal = None

--- a/dabo/ui/dDataControlMixin.py
+++ b/dabo/ui/dDataControlMixin.py
@@ -211,7 +211,8 @@ class dDataControlMixin(dControlMixin):
         ##- #if oldVal is None and curVal is None:
         ##-    # Could be changed and we just don't know it...
         ##- #    isChanged = True
-        if isinstance(self, dui.dToggleButton):
+
+        if isinstance(self, dui.dToggleButton.dToggleButton):
             # These classes change their value before the GotFocus event
             # can store the oldval, so always flush 'em.
             oldVal = None

--- a/dabo/ui/dDatePicker.py
+++ b/dabo/ui/dDatePicker.py
@@ -54,7 +54,7 @@ class dDatePicker(dDataControlMixin, wx_adv.DatePickerCtrl):
         self._timePart = [0, 0, 0, 0]
         self._lastWasNone = True
         self._baseClass = dDatePicker
-        wxClass = wx.DatePickerCtrl
+        preClass = wx.PreDatePickerCtrl
         pickerMode = self._extractKey((properties, attProperties, kwargs),
                 "PickerMode", "Dropdown")[:1].lower()
         if pickerMode not in "ds":
@@ -65,7 +65,7 @@ class dDatePicker(dDataControlMixin, wx_adv.DatePickerCtrl):
             kwargs["style"] |= wx.DP_ALLOWNONE
         if self._extractKey((properties, attProperties, kwargs), "ForceShowCentury", False):
             kwargs["style"] |= wx.DP_SHOWCENTURY
-        dDataControlMixin.__init__(self, wxClass, parent,
+        dDataControlMixin.__init__(self, preClass, parent,
             properties, attProperties, *args, **kwargs)
         self._bindKeys()
 

--- a/dabo/ui/dDatePicker.py
+++ b/dabo/ui/dDatePicker.py
@@ -54,7 +54,7 @@ class dDatePicker(dDataControlMixin, wx_adv.DatePickerCtrl):
         self._timePart = [0, 0, 0, 0]
         self._lastWasNone = True
         self._baseClass = dDatePicker
-        preClass = wx.DatePickerCtrl
+        wxClass = wx.DatePickerCtrl
         pickerMode = self._extractKey((properties, attProperties, kwargs),
                 "PickerMode", "Dropdown")[:1].lower()
         if pickerMode not in "ds":
@@ -65,7 +65,7 @@ class dDatePicker(dDataControlMixin, wx_adv.DatePickerCtrl):
             kwargs["style"] |= wx.DP_ALLOWNONE
         if self._extractKey((properties, attProperties, kwargs), "ForceShowCentury", False):
             kwargs["style"] |= wx.DP_SHOWCENTURY
-        dDataControlMixin.__init__(self, preClass, parent,
+        dDataControlMixin.__init__(self, wxClass, parent,
             properties, attProperties, *args, **kwargs)
         self._bindKeys()
 

--- a/dabo/ui/dDatePicker.py
+++ b/dabo/ui/dDatePicker.py
@@ -65,8 +65,8 @@ class dDatePicker(dDataControlMixin, wx_adv.DatePickerCtrl):
             kwargs["style"] |= wx.DP_ALLOWNONE
         if self._extractKey((properties, attProperties, kwargs), "ForceShowCentury", False):
             kwargs["style"] |= wx.DP_SHOWCENTURY
-        super(dDatePicker, self).__init__(preClass, parent=parent, properties,
-                attProperties, *args, **kwargs)
+        dDataControlMixin.__init__(self, preClass, parent,
+            properties, attProperties, *args, **kwargs)
         self._bindKeys()
 
         if self.AllowNullDate:

--- a/dabo/ui/dDatePicker.py
+++ b/dabo/ui/dDatePicker.py
@@ -54,7 +54,7 @@ class dDatePicker(dDataControlMixin, wx_adv.DatePickerCtrl):
         self._timePart = [0, 0, 0, 0]
         self._lastWasNone = True
         self._baseClass = dDatePicker
-        preClass = wx.PreDatePickerCtrl
+        preClass = wx.DatePickerCtrl
         pickerMode = self._extractKey((properties, attProperties, kwargs),
                 "PickerMode", "Dropdown")[:1].lower()
         if pickerMode not in "ds":

--- a/dabo/ui/dDialog.py
+++ b/dabo/ui/dDialog.py
@@ -42,8 +42,8 @@ class dDialog(dFormMixin, wx.Dialog):
         except KeyError:
             kwargs["style"] = defaultStyle
 
-        wxClass = wx.Dialog
-        dFormMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreDialog
+        dFormMixin.__init__(self, preClass, parent, properties=properties,
                 *args, **kwargs)
 
         # Hook method, so that we add the buttons last

--- a/dabo/ui/dDialog.py
+++ b/dabo/ui/dDialog.py
@@ -43,8 +43,8 @@ class dDialog(dFormMixin, wx.Dialog):
             kwargs["style"] = defaultStyle
 
         preClass = wx.Dialog
-        super(dDialog, self).__init__(preClass, parent=parent,
-                properties=properties, *args, **kwargs)
+        dFormMixin.__init__(self, preClass, parent, properties=properties,
+                *args, **kwargs)
 
         # Hook method, so that we add the buttons last
         self._addControls()
@@ -265,8 +265,7 @@ class dStandardButtonDialog(dDialog):
         if self._ok and self._yes:
             raise ValueError(_("Dialogs cannot have both 'OK' and 'Yes' buttons."))
         self._cancelOnEscape = True
-        super(dStandardButtonDialog, self).__init__(parent=parent,
-                properties=properties, *args, **kwargs)
+        super(dStandardButtonDialog, self).__init__(parent=parent, properties=properties, *args, **kwargs)
         self._baseClass = dStandardButtonDialog
         self._accepted = False
 

--- a/dabo/ui/dDialog.py
+++ b/dabo/ui/dDialog.py
@@ -42,8 +42,8 @@ class dDialog(dFormMixin, wx.Dialog):
         except KeyError:
             kwargs["style"] = defaultStyle
 
-        preClass = wx.Dialog
-        dFormMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.Dialog
+        dFormMixin.__init__(self, wxClass, parent, properties=properties,
                 *args, **kwargs)
 
         # Hook method, so that we add the buttons last

--- a/dabo/ui/dDialog.py
+++ b/dabo/ui/dDialog.py
@@ -42,7 +42,7 @@ class dDialog(dFormMixin, wx.Dialog):
         except KeyError:
             kwargs["style"] = defaultStyle
 
-        preClass = wx.PreDialog
+        preClass = wx.Dialog
         dFormMixin.__init__(self, preClass, parent, properties=properties,
                 *args, **kwargs)
 

--- a/dabo/ui/dDropdownList.py
+++ b/dabo/ui/dDropdownList.py
@@ -19,9 +19,8 @@ class dDropdownList(dControlItemMixin, wx.Choice):
         self._choices = []
 
         preClass = wx.Choice
-        super(dDropdownList, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initEvents(self):

--- a/dabo/ui/dDropdownList.py
+++ b/dabo/ui/dDropdownList.py
@@ -18,8 +18,8 @@ class dDropdownList(dControlItemMixin, wx.Choice):
         self._baseClass = dDropdownList
         self._choices = []
 
-        wxClass = wx.Choice
-        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreChoice
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dDropdownList.py
+++ b/dabo/ui/dDropdownList.py
@@ -18,7 +18,7 @@ class dDropdownList(dControlItemMixin, wx.Choice):
         self._baseClass = dDropdownList
         self._choices = []
 
-        preClass = wx.PreChoice
+        preClass = wx.Choice
         dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dDropdownList.py
+++ b/dabo/ui/dDropdownList.py
@@ -18,8 +18,8 @@ class dDropdownList(dControlItemMixin, wx.Choice):
         self._baseClass = dDropdownList
         self._choices = []
 
-        preClass = wx.Choice
-        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.Choice
+        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dEditBox.py
+++ b/dabo/ui/dEditBox.py
@@ -19,7 +19,7 @@ class dEditBox(dTextBoxMixin, wx.TextCtrl):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dEditBox
 
-        preClass = wx.PreTextCtrl
+        preClass = wx.TextCtrl
         kwargs["style"] = wx.TE_MULTILINE
         self._wordWrap = self._extractKey((properties, attProperties, kwargs),
                 "WordWrap", True)

--- a/dabo/ui/dEditBox.py
+++ b/dabo/ui/dEditBox.py
@@ -19,7 +19,7 @@ class dEditBox(dTextBoxMixin, wx.TextCtrl):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dEditBox
 
-        preClass = wx.TextCtrl
+        wxClass = wx.TextCtrl
         kwargs["style"] = wx.TE_MULTILINE
         self._wordWrap = self._extractKey((properties, attProperties, kwargs),
                 "WordWrap", True)
@@ -27,7 +27,7 @@ class dEditBox(dTextBoxMixin, wx.TextCtrl):
             kwargs["style"] = kwargs["style"] | wx.TE_BESTWRAP
         else:
             kwargs["style"] = kwargs["style"] | wx.TE_DONTWRAP
-        super(dEditBox, self).__init__(preClass, parent, properties=properties,
+        super(dEditBox, self).__init__(wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dEditBox.py
+++ b/dabo/ui/dEditBox.py
@@ -19,7 +19,7 @@ class dEditBox(dTextBoxMixin, wx.TextCtrl):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dEditBox
 
-        wxClass = wx.TextCtrl
+        preClass = wx.PreTextCtrl
         kwargs["style"] = wx.TE_MULTILINE
         self._wordWrap = self._extractKey((properties, attProperties, kwargs),
                 "WordWrap", True)
@@ -27,7 +27,7 @@ class dEditBox(dTextBoxMixin, wx.TextCtrl):
             kwargs["style"] = kwargs["style"] | wx.TE_BESTWRAP
         else:
             kwargs["style"] = kwargs["style"] | wx.TE_DONTWRAP
-        super(dEditBox, self).__init__(wxClass, parent, properties=properties,
+        dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dEditableList.py
+++ b/dabo/ui/dEditableList.py
@@ -43,9 +43,8 @@ class dEditableList(dControlMixin, wx_adv.EditableListBox):
         self._upButton = None
         self._panel = None
 
-        super(dEditableList, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def GetValue(self):

--- a/dabo/ui/dEditor.py
+++ b/dabo/ui/dEditor.py
@@ -158,7 +158,7 @@ class STCPrintout(wx.Printout):
     linesPerPage = 80
 
     def __init__(self, stc, colourMode=0, filename='', doPageNums=1):
-        super(STCPrintout, self).__init__()
+        wx.Printout.__init__(self)
         self.stc = stc
         self.colourMode = colourMode
         self.filename = filename
@@ -279,9 +279,9 @@ class dEditor(dDataControlMixin, stc.StyledTextCtrl):
         self._classPat = re.compile(r"^\s*class ([^\(]+)\(([^\)]*?)\)")
         self._defPat = re.compile(r"^\s*def ")
 
-        super(dEditor, self).__init__(self, preClass=None, parent=parent,
-                style = wx.NO_BORDER, name=name, properties=properties,
-                attProperties=attProperties, _explicitName=_explicitName, 
+        stc.StyledTextCtrl.__init__(self, parent, -1, style = wx.NO_BORDER)
+        dDataControlMixin.__init__(self, name, properties=properties,
+                attProperties=attProperties, _explicitName=_explicitName,
                 *args, **kwargs)
         self._afterInit()
 

--- a/dabo/ui/dEditor.py
+++ b/dabo/ui/dEditor.py
@@ -238,7 +238,7 @@ class dEditor(dDataControlMixin, stc.StyledTextCtrl):
         self._baseClass = dEditor
         self._fileName = ""
         self._fileModTime = None
-        self._beforeInit()
+        self._beforeInit(None)
         name, _explicitName = self._processName(kwargs, self.__class__.__name__)
         # Declare the attributes that underly properties.
         self._autoCompleteList = False
@@ -254,6 +254,7 @@ class dEditor(dDataControlMixin, stc.StyledTextCtrl):
         self._edgeGuideColumn = 80
         self._encoding = dabo.getEncoding()
         self._eolMode = ""
+        self._useAntiAliasing = True
         self._codeFolding = True
         self._showLineNumbers = True
         self._showEOL = False
@@ -279,10 +280,10 @@ class dEditor(dDataControlMixin, stc.StyledTextCtrl):
         self._classPat = re.compile(r"^\s*class ([^\(]+)\(([^\)]*?)\)")
         self._defPat = re.compile(r"^\s*def ")
 
-        stc.StyledTextCtrl.__init__(self, parent, -1, style = wx.NO_BORDER)
+        stc.StyledTextCtrl.__init__(self, parent, -1,
+                                    style = wx.NO_BORDER)
         dDataControlMixin.__init__(self, name, properties=properties,
-                attProperties=attProperties, _explicitName=_explicitName,
-                *args, **kwargs)
+                                       attProperties=attProperties, _explicitName=_explicitName, *args, **kwargs)
         self._afterInit()
 
         self._printData = wx.PrintData()
@@ -727,6 +728,7 @@ class dEditor(dDataControlMixin, stc.StyledTextCtrl):
         self.SetViewWhiteSpace(self.ShowWhiteSpace)
         self.SetBufferedDraw(self.BufferedDrawing)
         self.SetViewEOL(self.ShowEOL)
+        self.SetUseAntiAliasing(self.UseAntiAliasing)
 
         ## Seems that eolmode is CRLF on Mac by default... explicitly set it if not set by user!
         if not self.EOLMode:
@@ -2436,6 +2438,17 @@ Do you want to overwrite it?""")
         self.SetText(val)
 
 
+    def _getUseAntiAliasing(self):
+        return self._useAntiAliasing
+
+    def _setUseAntiAliasing(self, val):
+        if self._constructed():
+            self._useAntiAliasing = val
+            self.SetUseAntiAliasing(val)
+        else:
+            self._properties["UseAntiAliasing"] = val
+
+
     def _getUseBookmarks(self):
         return self._useBookmarks
 
@@ -2556,22 +2569,24 @@ Do you want to overwrite it?""")
                 - "down arrow"
                 - "arrow"
                 - "arrows"
-                - "rectangle\" """))
+                - "rectangle\""""))
 
     BufferedDrawing = property(_getBufferedDrawing, _setBufferedDrawing, None,
-            _("Setting to True (default) reduces display flicker  (bool)"))
+                               _("Setting to True (default) reduces display flicker  (bool)"))
 
     CodeCompletion = property(_getCodeCompletion, _setCodeCompletion, None,
-            _("Determines if code completion is active (default=True)  (bool)"))
+                              _("Determines if code completion is active (default=True)  (bool)"))
 
     Column = property(_getColumn, _setColumn, None,
-            _("""Returns the current column position of the cursor in the file  (int)"""))
+                      _("""Returns the current column position of the cursor in the
+            file  (int)"""))
 
     CommentString = property(_getCommentString, _setCommentString, None,
                              _("String used to prefix lines that are commented out  (str)"))
 
     EdgeGuideColumn = property(_getEdgeGuideColumn, _setEdgeGuideColumn, None,
-            _("""If self.EdgeGuide is set to True, specifies the column position the guide is in(int)"""))
+                               _("""If self.EdgeGuide is set to True, specifies the column
+            position the guide is in(int)"""))
 
     Encoding = property(_getEncoding, _setEncoding, None,
                         _("Type of encoding to use. Defaults to Dabo's encoding.  (str)"))
@@ -2670,6 +2685,9 @@ Do you want to overwrite it?""")
 
     Text = property(_getText, _setText, None,
                     _("Current contents of the editor  (str)"))
+
+    UseAntiAliasing = property(_getUseAntiAliasing, _setUseAntiAliasing, None,
+                               _("Controls whether fonts are anti-aliased (default=True)  (bool)"))
 
     UseBookmarks = property(_getUseBookmarks, _setUseBookmarks, None,
                             _("Are we tracking bookmarks in the editor? Default=False  (bool)"))

--- a/dabo/ui/dForm.py
+++ b/dabo/ui/dForm.py
@@ -22,9 +22,8 @@ class BaseForm(dFormMixin):
     dForm knows how to handle one or more dBizobjs, providing proxy methods
     like next(), last(), save(), and requery().
     """
-    def __init__(self, preClass, parent, properties, attProperties, *args,
+    def __init__(self, wxClass, parent, properties, attProperties, *args,
             **kwargs):
-        print("BaseForm INIT")
         self.bizobjs = {}
         self._primaryBizobj = None
         self._dataUpdateDelay = 100
@@ -39,9 +38,8 @@ class BaseForm(dFormMixin):
         # or a requery is about to happen.
         self._checkForChanges = True
 
-        super(BaseForm, self).__init__(preClass, parent, properties=properties,
+        dFormMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
-        print("BaseForm SUPER called")
 
         # Used to override some cases where the status
         # text should be displayed despite other processes
@@ -1023,32 +1021,30 @@ Database error message: %s""") %     err
 class dForm(BaseForm, wx.Frame):
     def __init__(self, parent=None, properties=None, attProperties=None, *args,
             **kwargs):
-        print("dForm INIT")
         self._baseClass = dForm
         self._mdi = False
         if kwargs.pop("Modal", False):
             # Hack this into a wx.Dialog, for true modality
             dForm._hackToDialog()
-            preClass = wx.Dialog
+            wxClass = wx.Dialog
             self._modal = True
         else:
             # Normal dForm
             if dabo.MDI and isinstance(parent, wx.MDIParentFrame):
                 # Hack this into an MDI Child:
                 self._mdi = True
-                preClass = wx.MDIChildFrame
+                wxClass = wx.MDIChildFrame
             else:
                 # This is a normal SDI form:
                 self._mdi = False
-                preClass = wx.Frame
+                wxClass = wx.Frame
             dForm._hackToFrame()
 
         ## (Note that it is necessary to run the above blocks each time, because
         ##  we are modifying the dForm class definition globally.)
-        super(dForm, self).__init__(preClass, parent=parent,
+        super(dForm, self).__init__(wxClass, parent=parent,
                 properties=properties, attProperties=attProperties,
                 *args, **kwargs)
-        print("dForm SUPER called")
         dForm._hackToFrame()
 
 

--- a/dabo/ui/dForm.py
+++ b/dabo/ui/dForm.py
@@ -24,6 +24,7 @@ class BaseForm(dFormMixin):
     """
     def __init__(self, preClass, parent, properties, attProperties, *args,
             **kwargs):
+        print("BaseForm INIT")
         self.bizobjs = {}
         self._primaryBizobj = None
         self._dataUpdateDelay = 100
@@ -40,6 +41,7 @@ class BaseForm(dFormMixin):
 
         super(BaseForm, self).__init__(preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
+        print("BaseForm SUPER called")
 
         # Used to override some cases where the status
         # text should be displayed despite other processes
@@ -1021,6 +1023,7 @@ Database error message: %s""") %     err
 class dForm(BaseForm, wx.Frame):
     def __init__(self, parent=None, properties=None, attProperties=None, *args,
             **kwargs):
+        print("dForm INIT")
         self._baseClass = dForm
         self._mdi = False
         if kwargs.pop("Modal", False):
@@ -1045,6 +1048,7 @@ class dForm(BaseForm, wx.Frame):
         super(dForm, self).__init__(preClass, parent=parent,
                 properties=properties, attProperties=attProperties,
                 *args, **kwargs)
+        print("dForm SUPER called")
         dForm._hackToFrame()
 
 
@@ -1119,8 +1123,8 @@ class dToolForm(BaseForm, wx.MiniFrame):
         kwargs["TinyTitleBar"] = True
         kwargs["ShowStatusBar"] = False
         kwargs["ShowToolBar"] = False
-        super(dToolForm, self).__init__(parent=parent, properties=properties,
-                attProperties=attProperties, *args, **kwargs)
+        BaseForm.__init__(self, parent, properties=properties, attProperties=attProperties,
+                *args, **kwargs)
 
 
 class dBorderlessForm(BaseForm, wx.Frame):
@@ -1131,8 +1135,8 @@ class dBorderlessForm(BaseForm, wx.Frame):
         kwargs["ShowStatusBar"] = False
         kwargs["ShowSystemMenu"] = False
         kwargs["MenuBarClass"] = None
-        super(dBorderlessForm, self).__init__(parent=parent, properties=properties,
-                attProperties=attProperties, *args, **kwargs)
+        BaseForm.__init__(self, parent, properties=properties, attProperties=attProperties,
+                *args, **kwargs)
 
 
 class _dForm_test(dForm):

--- a/dabo/ui/dForm.py
+++ b/dabo/ui/dForm.py
@@ -4,15 +4,13 @@ import time
 import wx
 import dabo
 from dabo import ui as dui
+from dabo.ui import makeDynamicProperty
 from dabo import dEvents as dEvents
+from dabo.ui.dFormMixin import dFormMixin
 from dabo import dException as dException
 from dabo.dLocalize import _
 from dabo.lib.utils import ustr
-from dabo.ui import makeDynamicProperty
-from dabo.ui.dButton import dButton
 from dabo.ui.dDialog import dDialog
-from dabo.ui.dFormMixin import dFormMixin
-from dabo.ui.dSizer import dSizer
 
 
 class BaseForm(dFormMixin):
@@ -22,8 +20,7 @@ class BaseForm(dFormMixin):
     dForm knows how to handle one or more dBizobjs, providing proxy methods
     like next(), last(), save(), and requery().
     """
-    def __init__(self, wxClass, parent, properties, attProperties, *args,
-            **kwargs):
+    def __init__(self, preClass, parent, properties, attProperties, *args, **kwargs):
         self.bizobjs = {}
         self._primaryBizobj = None
         self._dataUpdateDelay = 100
@@ -38,7 +35,7 @@ class BaseForm(dFormMixin):
         # or a requery is about to happen.
         self._checkForChanges = True
 
-        dFormMixin.__init__(self, wxClass, parent, properties=properties,
+        dFormMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
         # Used to override some cases where the status
@@ -55,7 +52,7 @@ class BaseForm(dFormMixin):
 
 
     def _afterInit(self):
-        self.Sizer = dSizer("vertical")
+        self.Sizer = dui.dSizer("vertical")
         self.Sizer.layout()
         super(BaseForm, self)._afterInit()
         if self.RequeryOnLoad:
@@ -1019,46 +1016,44 @@ Database error message: %s""") %     err
 
 
 class dForm(BaseForm, wx.Frame):
-    def __init__(self, parent=None, properties=None, attProperties=None, *args,
-            **kwargs):
+    def __init__(self, parent=None, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dForm
         self._mdi = False
+
         if kwargs.pop("Modal", False):
             # Hack this into a wx.Dialog, for true modality
             dForm._hackToDialog()
-            wxClass = wx.Dialog
+            preClass = wx.PreDialog
             self._modal = True
         else:
             # Normal dForm
             if dabo.MDI and isinstance(parent, wx.MDIParentFrame):
                 # Hack this into an MDI Child:
+                preClass = wx.PreMDIChildFrame
                 self._mdi = True
-                wxClass = wx.MDIChildFrame
             else:
                 # This is a normal SDI form:
+                preClass = wx.PreFrame
                 self._mdi = False
-                wxClass = wx.Frame
             dForm._hackToFrame()
 
         ## (Note that it is necessary to run the above blocks each time, because
         ##  we are modifying the dForm class definition globally.)
-        super(dForm, self).__init__(wxClass, parent=parent,
-                properties=properties, attProperties=attProperties,
+        BaseForm.__init__(self, preClass, parent, properties=properties, attProperties=attProperties,
                 *args, **kwargs)
         dForm._hackToFrame()
 
 
-    @classmethod
     def _hackToDialog(cls):
         dForm.__bases__ = (BaseForm, wx.Dialog)
+    _hackToDialog = classmethod(_hackToDialog)
 
-    @classmethod
     def _hackToFrame(cls):
         if dabo.MDI:
             dForm.__bases__ = (BaseForm, wx.MDIChildFrame)
         else:
             dForm.__bases__ = (BaseForm, wx.Frame)
-
+    _hackToFrame = classmethod(_hackToFrame)
 
     def Show(self, show=True):
         if self.Modal:
@@ -1109,9 +1104,11 @@ class dForm(BaseForm, wx.Frame):
             _("Specifies whether the form is shown or hidden.  (bool)"))
 
 
+
 class dToolForm(BaseForm, wx.MiniFrame):
     def __init__(self, parent=None, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dToolForm
+        preClass = wx.PreMiniFrame
         self._mdi = False
         style = kwargs.get("style", 0)
         kwargs["style"] = style | wx.RESIZE_BORDER | wx.CAPTION | wx.MINIMIZE_BOX | \
@@ -1119,8 +1116,9 @@ class dToolForm(BaseForm, wx.MiniFrame):
         kwargs["TinyTitleBar"] = True
         kwargs["ShowStatusBar"] = False
         kwargs["ShowToolBar"] = False
-        BaseForm.__init__(self, parent, properties=properties, attProperties=attProperties,
+        BaseForm.__init__(self, preClass, parent, properties=properties, attProperties=attProperties,
                 *args, **kwargs)
+
 
 
 class dBorderlessForm(BaseForm, wx.Frame):
@@ -1131,8 +1129,10 @@ class dBorderlessForm(BaseForm, wx.Frame):
         kwargs["ShowStatusBar"] = False
         kwargs["ShowSystemMenu"] = False
         kwargs["MenuBarClass"] = None
-        BaseForm.__init__(self, parent, properties=properties, attProperties=attProperties,
+        preClass = wx.PreFrame
+        BaseForm.__init__(self, preClass, parent, properties=properties, attProperties=attProperties,
                 *args, **kwargs)
+
 
 
 class _dForm_test(dForm):
@@ -1143,20 +1143,19 @@ class _dForm_test(dForm):
     def onDeactivate(self, evt):
         print(_("Deactivate"))
 
-
 class _dBorderlessForm_test(dBorderlessForm):
     def afterInit(self):
-        self.btn = dButton(self, Caption=_("Close Borderless Form"))
+        self.btn = dui.dButton(self, Caption=_("Close Borderless Form"))
         self.Sizer.append(self.btn, halign="Center", valign="middle")
         self.layout()
         self.btn.bindEvent(dEvents.Hit, self.close)
         dui.callAfter(self.setSize)
 
-
     def setSize(self):
         self.Width, self.Height = self.btn.Width + 60, self.btn.Height + 60
         self.layout()
         self.Centered = True
+
 
 
 if __name__ == "__main__":

--- a/dabo/ui/dForm.py
+++ b/dabo/ui/dForm.py
@@ -52,7 +52,8 @@ class BaseForm(dFormMixin):
 
 
     def _afterInit(self):
-        self.Sizer = dui.dSizer("vertical")
+        from dabo.ui.dSizer import dSizer
+        self.Sizer = dSizer("vertical")
         self.Sizer.layout()
         super(BaseForm, self)._afterInit()
         if self.RequeryOnLoad:
@@ -80,7 +81,7 @@ class BaseForm(dFormMixin):
         this in your own classes if you prefer a different display.
         """
         if exception and not dabo.eatBizExceptions:
-            raise
+            raise exception
         if severe:
             func = dui.stop
         else:
@@ -1023,17 +1024,17 @@ class dForm(BaseForm, wx.Frame):
         if kwargs.pop("Modal", False):
             # Hack this into a wx.Dialog, for true modality
             dForm._hackToDialog()
-            preClass = wx.PreDialog
+            preClass = wx.Dialog
             self._modal = True
         else:
             # Normal dForm
             if dabo.MDI and isinstance(parent, wx.MDIParentFrame):
                 # Hack this into an MDI Child:
-                preClass = wx.PreMDIChildFrame
+                preClass = wx.MDIChildFrame
                 self._mdi = True
             else:
                 # This is a normal SDI form:
-                preClass = wx.PreFrame
+                preClass = wx.Frame
                 self._mdi = False
             dForm._hackToFrame()
 
@@ -1108,7 +1109,7 @@ class dForm(BaseForm, wx.Frame):
 class dToolForm(BaseForm, wx.MiniFrame):
     def __init__(self, parent=None, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dToolForm
-        preClass = wx.PreMiniFrame
+        preClass = wx.MiniFrame
         self._mdi = False
         style = kwargs.get("style", 0)
         kwargs["style"] = style | wx.RESIZE_BORDER | wx.CAPTION | wx.MINIMIZE_BOX | \
@@ -1129,7 +1130,7 @@ class dBorderlessForm(BaseForm, wx.Frame):
         kwargs["ShowStatusBar"] = False
         kwargs["ShowSystemMenu"] = False
         kwargs["MenuBarClass"] = None
-        preClass = wx.PreFrame
+        preClass = wx.Frame
         BaseForm.__init__(self, preClass, parent, properties=properties, attProperties=attProperties,
                 *args, **kwargs)
 

--- a/dabo/ui/dFormMain.py
+++ b/dabo/ui/dFormMain.py
@@ -7,17 +7,15 @@ from dabo.ui.dFormMixin import dFormMixin
 
 class dFormMainBase(dFormMixin):
     """This is the main top-level form for the application."""
-    def __init__(self, preClass, parent=None, properties=None, *args, **kwargs):
-        print("dFormMainBase INIT")
-        super(dFormMainBase, self).__init__(preClass, parent, properties,
-                *args, **kwargs)
-        print("dFormMainBase SUPER called")
+    def __init__(self, wxClass, parent=None, properties=None, *args, **kwargs):
+        dFormMixin.__init__(self, wxClass, parent, properties, *args, **kwargs)
 
 
     def _beforeClose(self, evt=None):
         # In wxPython 4.x, a 'dead object' is now a logical False.
         forms2close = [frm for frm in self.Application.uiForms
                 if frm and frm is not self]
+                # if frm is not self and not isinstance(frm, dabo.ui.deadObject)]
         while forms2close:
             frm = forms2close[0]
             # This will allow forms to veto closing (i.e., user doesn't
@@ -34,7 +32,6 @@ class dFormMainBase(dFormMixin):
 
 class dFormMain(dFormMainBase, wx.Frame):
     def __init__(self, parent=None, properties=None, *args, **kwargs):
-        print("dFormMain INIT")
         self._baseClass = dFormMain
 
         if dabo.MDI:
@@ -49,7 +46,7 @@ class dFormMain(dFormMainBase, wx.Frame):
         ##  we are modifying the dFormMain class definition globally.)
 
         super(dFormMain, self).__init__(parent, properties, *args, **kwargs)
-        print("dFormMain SUPER called")
+#        dFormMainBase.__init__(self, wxClass, parent, properties, *args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/dabo/ui/dFormMain.py
+++ b/dabo/ui/dFormMain.py
@@ -37,12 +37,12 @@ class dFormMain(dFormMainBase, wx.Frame):
         if dabo.MDI:
             # Hack this into an MDI Parent:
             dFormMain.__bases__ = (dFormMainBase, wx.MDIParentFrame)
-            preClass = wx.PreMDIParentFrame
+            preClass = wx.MDIParentFrame
             self._mdi = True
         else:
             # This is a normal SDI form:
             dFormMain.__bases__ = (dFormMainBase, wx.Frame)
-            preClass = wx.PreFrame
+            preClass = wx.Frame
             self._mdi = False
         ## (Note that it is necessary to run the above block each time, because
         ##  we are modifying the dFormMain class definition globally.)

--- a/dabo/ui/dFormMain.py
+++ b/dabo/ui/dFormMain.py
@@ -7,8 +7,8 @@ from dabo.ui.dFormMixin import dFormMixin
 
 class dFormMainBase(dFormMixin):
     """This is the main top-level form for the application."""
-    def __init__(self, wxClass, parent=None, properties=None, *args, **kwargs):
-        dFormMixin.__init__(self, wxClass, parent, properties, *args, **kwargs)
+    def __init__(self, preClass, parent=None, properties=None, *args, **kwargs):
+        dFormMixin.__init__(self, preClass, parent, properties, *args, **kwargs)
 
 
     def _beforeClose(self, evt=None):
@@ -36,17 +36,18 @@ class dFormMain(dFormMainBase, wx.Frame):
 
         if dabo.MDI:
             # Hack this into an MDI Parent:
-            dFormMain.__bases__ = (wx.MDIParentFrame, dFormMainBase)
+            dFormMain.__bases__ = (dFormMainBase, wx.MDIParentFrame)
+            preClass = wx.PreMDIParentFrame
             self._mdi = True
         else:
             # This is a normal SDI form:
-            dFormMain.__bases__ = (wx.Frame, dFormMainBase)
+            dFormMain.__bases__ = (dFormMainBase, wx.Frame)
+            preClass = wx.PreFrame
             self._mdi = False
         ## (Note that it is necessary to run the above block each time, because
         ##  we are modifying the dFormMain class definition globally.)
 
-        super(dFormMain, self).__init__(parent, properties, *args, **kwargs)
-#        dFormMainBase.__init__(self, wxClass, parent, properties, *args, **kwargs)
+        dFormMainBase.__init__(self, preClass, parent, properties, *args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/dabo/ui/dFormMixin.py
+++ b/dabo/ui/dFormMixin.py
@@ -20,9 +20,8 @@ from dabo.ui import makeDynamicProperty
 
 
 class dFormMixin(dPemMixin):
-    def __init__(self, preClass, parent=None, properties=None, attProperties=None,
+    def __init__(self, wxClass, parent=None, properties=None, attProperties=None,
             src=None, *args, **kwargs):
-        print("dFormMixin INIT")
         self._cxnName = ""
         self._connection = None
         self._floatingPanel = None
@@ -77,10 +76,8 @@ class dFormMixin(dPemMixin):
         # Flag to prevent infinite loops when doing field-level validation
         self._fieldValidationControl = None
 
-        super(dFormMixin, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
-        print("dFormMixin SUPER called")
+        super(dFormMixin, self).__init__(wxClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         dui.callAfter(self._createStatusBar)
         self._createToolBar()
@@ -98,9 +95,9 @@ class dFormMixin(dPemMixin):
         mbc = self.MenuBarClass
         if app and mbc and self.ShowMenuBar:
             if isinstance(mbc, str):
-                self.MenuBar = dui.createMenuBar(mbc, parent=self)
+                self.MenuBar = dui.createMenuBar(mbc, self)
             else:
-                self.MenuBar = mbc(parent=self)
+                self.MenuBar = mbc()
             self.afterSetMenuBar()
         if not self.Icon:
             if app:

--- a/dabo/ui/dFormMixin.py
+++ b/dabo/ui/dFormMixin.py
@@ -169,7 +169,7 @@ class dFormMixin(dPemMixin):
             if mb:
                 pref_id = getattr(mb, "_mac_pref_menu_item_id", None)
                 if pref_id:
-                    wx.App_SetMacPreferencesMenuItemId(pref_id)
+                    wx.PyApp.SetMacPreferencesMenuItemId(pref_id)
         else:
             self.raiseEvent(dEvents.Deactivate, evt)
         evt.Skip()

--- a/dabo/ui/dFormMixin.py
+++ b/dabo/ui/dFormMixin.py
@@ -20,7 +20,7 @@ from dabo.ui import makeDynamicProperty
 
 
 class dFormMixin(dPemMixin):
-    def __init__(self, wxClass, parent=None, properties=None, attProperties=None,
+    def __init__(self, preClass, parent=None, properties=None, attProperties=None,
             src=None, *args, **kwargs):
         self._cxnName = ""
         self._connection = None
@@ -76,7 +76,7 @@ class dFormMixin(dPemMixin):
         # Flag to prevent infinite loops when doing field-level validation
         self._fieldValidationControl = None
 
-        super(dFormMixin, self).__init__(wxClass, parent, properties=properties,
+        super(dFormMixin, self).__init__(preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
         dui.callAfter(self._createStatusBar)
@@ -99,6 +99,7 @@ class dFormMixin(dPemMixin):
             else:
                 self.MenuBar = mbc()
             self.afterSetMenuBar()
+
         if not self.Icon:
             if app:
                 self.Icon = app.Icon
@@ -168,7 +169,7 @@ class dFormMixin(dPemMixin):
             if mb:
                 pref_id = getattr(mb, "_mac_pref_menu_item_id", None)
                 if pref_id:
-                    wx.PyApp.SetMacPreferencesMenuItemId(pref_id)
+                    wx.App_SetMacPreferencesMenuItemId(pref_id)
         else:
             self.raiseEvent(dEvents.Deactivate, evt)
         evt.Skip()

--- a/dabo/ui/dFormMixin.py
+++ b/dabo/ui/dFormMixin.py
@@ -22,6 +22,7 @@ from dabo.ui import makeDynamicProperty
 class dFormMixin(dPemMixin):
     def __init__(self, preClass, parent=None, properties=None, attProperties=None,
             src=None, *args, **kwargs):
+        print("dFormMixin INIT")
         self._cxnName = ""
         self._connection = None
         self._floatingPanel = None
@@ -79,9 +80,9 @@ class dFormMixin(dPemMixin):
         super(dFormMixin, self).__init__(preClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args,
                 **kwargs)
+        print("dFormMixin SUPER called")
 
-#        dui.callAfter(self._createStatusBar)
-        self._createStatusBar()
+        dui.callAfter(self._createStatusBar)
         self._createToolBar()
 
 
@@ -215,7 +216,6 @@ class dFormMixin(dPemMixin):
 
 
     def _createStatusBar(self):
-        print("CREATE STATUS BAR CALLED", self)
         modal = getattr(self, "Modal", False)
         if (self and self.ShowStatusBar
                 and self.StatusBar is None
@@ -224,7 +224,6 @@ class dFormMixin(dPemMixin):
                 and (sys.platform.startswith("darwin") or not isinstance(self, wx.MDIChildFrame))):
             SBC = self.StatusBarClass
             self.StatusBar = SBC(self)
-        print("CREATE STATUS BAR DONE", self)
 
 
     def __onDeactivate(self, evt):
@@ -396,8 +395,8 @@ class dFormMixin(dPemMixin):
 
 
     def Show(self, *args, **kwargs):
-        super(dFormMixin, self).Show(*args, **kwargs)
         self.restoreSizeAndPositionIfNeeded()
+        super(dFormMixin, self).Show(*args, **kwargs)
 
 
     def showModal(self):
@@ -574,8 +573,7 @@ class dFormMixin(dPemMixin):
             self.Left = max(0, self.Left)
             self.Top = max(minTop, self.Top)
 
-#        self.WindowState = state
-        dabo.ui.setAfter(self, "WindowState", state)
+        self.WindowState = state
 
 
     def saveSizeAndPosition(self):
@@ -1018,9 +1016,7 @@ class dFormMixin(dPemMixin):
 
     def _setStatusBar(self, val):
         try:
-            print("Before call to SetStatusBar")
             self.SetStatusBar(val)
-            print("After call to SetStatusBar")
         except (TypeError, AttributeError):
             # dialogs don't have status bars
             pass

--- a/dabo/ui/dGauge.py
+++ b/dabo/ui/dGauge.py
@@ -12,8 +12,8 @@ class dGauge(dControlMixin, wx.Gauge):
     """Creates a gauge, which can be used as a progress bar."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dGauge
-        preClass = wx.Gauge
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.Gauge
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dGauge.py
+++ b/dabo/ui/dGauge.py
@@ -13,7 +13,7 @@ class dGauge(dControlMixin, wx.Gauge):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dGauge
         preClass = wx.Gauge
-        super(dGauge, self).__init__(preClass, parent=parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dGauge.py
+++ b/dabo/ui/dGauge.py
@@ -12,7 +12,7 @@ class dGauge(dControlMixin, wx.Gauge):
     """Creates a gauge, which can be used as a progress bar."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dGauge
-        preClass = wx.PreGauge
+        preClass = wx.Gauge
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dGauge.py
+++ b/dabo/ui/dGauge.py
@@ -12,8 +12,8 @@ class dGauge(dControlMixin, wx.Gauge):
     """Creates a gauge, which can be used as a progress bar."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dGauge
-        wxClass = wx.Gauge
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreGauge
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dGlWindow.py
+++ b/dabo/ui/dGlWindow.py
@@ -34,7 +34,7 @@ class dGlWindow(dControlMixin, glcanvas.GLCanvas):
 
         self._baseClass = dGlWindow
         preClass = glcanvas.GLCanvas
-        super(dGlWindow, self).__init__(preClass, parent=parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def initGL(self):

--- a/dabo/ui/dGrid.py
+++ b/dabo/ui/dGrid.py
@@ -49,7 +49,7 @@ decimalPoint = None
 
 
 
-class dGridDataTable(wx.grid.GridTableBase):
+class dGridDataTable(wx.grid.PyGridTableBase):
 
     def __init__(self, parent):
         super(dGridDataTable, self).__init__()
@@ -282,28 +282,28 @@ class dGridDataTable(wx.grid.GridTableBase):
 
     # The following methods are required by the grid, to find out certain
     # important details about the underlying table.
-    def GetNumberRows(self):
-        bizobj = self.grid.getBizobj()
-        if bizobj:
-            return bizobj.RowCount
-        try:
-            num = len(self.grid.DataSet)
-        except:
-            num = 0
-        return num
+#    def GetNumberRows(self):
+#        bizobj = self.grid.getBizobj()
+#        if bizobj:
+#            return bizobj.RowCount
+#        try:
+#            num = len(self.grid.DataSet)
+#        except:
+#            num = 0
+#        return num
 
 
-    def GetNumberCols(self, useNative=False):
-        if useNative:
-            return super(dGridDataTable, self).GetNumberCols()
-        else:
-            return self.grid.ColumnCount
+#    def GetNumberCols(self, useNative=False):
+#        if useNative:
+#            return super(dGridDataTable, self).GetNumberCols()
+#        else:
+#            return self.grid.ColumnCount
 
 
-    def IsEmptyCell(self, row, col):
-        if row >= self.grid.RowCount:
-            return True
-        return False
+#    def IsEmptyCell(self, row, col):
+#        if row >= self.grid.RowCount:
+#            return True
+#        return False
 
 
     def GetValue(self, row, col, useCache=True, convertNoneToString=True,
@@ -1819,7 +1819,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
         if decimalPoint is None:
             decimalPoint = locale.localeconv()["decimal_point"]
         # Get scrollbar size from system metrics.
-        self._scrollBarSize = wx.SystemSettings.GetMetric(wx.SYS_VSCROLL_X)
+        self._scrollBarSize = wx.SystemSettings_GetMetric(wx.SYS_VSCROLL_X)
         self._baseClass = dGrid
         preClass = wx.grid.Grid
 

--- a/dabo/ui/dGrid.py
+++ b/dabo/ui/dGrid.py
@@ -488,8 +488,7 @@ class dColumn(dPemMixin):
 
         self._gridCellAttrs = {}
 
-        super(dColumn, self).__init__(preClass=None, parent=parent,
-                properties=properties, attProperties=attProperties,
+        super(dColumn, self).__init__(properties=properties, attProperties=attProperties,
                 *args, **kwargs)
         self._baseClass = dColumn
         if dataFieldSent and not dataTypeSent:
@@ -1917,7 +1916,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
         self._rowColorEven = "white"
         self._rowColorOdd = (212, 255, 212)        # very light green
 
-        super(dGrid, self).__init__(preClass, parent=parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
         # Reduces grid flickering on Windows platform.

--- a/dabo/ui/dGridSizer.py
+++ b/dabo/ui/dGridSizer.py
@@ -23,6 +23,8 @@ class dGridSizer(dSizerMixin, wx.GridBagSizer):
         """
         self._baseClass = dGridSizer
         self._parent = None
+        wx.GridBagSizer.__init__(self)    ##, vgap=vgap, hgap=hgap)
+
         self._maxRows = 0
         self._maxCols = 0
         self._maxDimension = "c"
@@ -42,7 +44,7 @@ class dGridSizer(dSizerMixin, wx.GridBagSizer):
             bad = ", ".join(list(kwargs.keys()))
             raise TypeError(("Invalid keyword arguments passed to dGridSizer: %s") % bad)
 
-        super(dGridSizer, self).__init__(*args, **kwargs)
+        dSizerMixin.__init__(self, *args, **kwargs)
 
 
     def append(self, item, layout="normal", row=-1, col=-1,

--- a/dabo/ui/dHtmlBox.py
+++ b/dabo/ui/dHtmlBox.py
@@ -32,9 +32,8 @@ class dHtmlBox(dControlMixin, wx.html.HtmlWindow):
         self._source = self._page = ""
         self._respondToLinks = True
         self._openLinksInBrowser = False
-        super(dHtmlBox, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
         self.SetScrollRate(10, 10)
         if wx.VERSION >= (2, 7):
             self.Bind(wx.html.EVT_HTML_LINK_CLICKED, self.__onWxLinkClicked)

--- a/dabo/ui/dHyperLink.py
+++ b/dabo/ui/dHyperLink.py
@@ -22,9 +22,8 @@ class dHyperLink(dControlMixin, AlignmentMixin, hyperlink.HyperLinkCtrl):
         self._baseClass = dHyperLink
         preClass = hyperlink.HyperLinkCtrl
 
-        super(dHyperLink, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         # Make the rollover effect the default, unless it was specified as False.
         self.ShowHover = self.ShowHover

--- a/dabo/ui/dImage.py
+++ b/dabo/ui/dImage.py
@@ -67,8 +67,8 @@ class dImage(dDataControlMixin, dImageMixin, wx.StaticBitmap):
         picName = self._extractKey((kwargs, properties, attProperties), "Picture", "")
         self._pictureIndex = self._extractKey((kwargs, properties, attProperties), "PictureIndex", -1)
 
-        super(dImage, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties,
+        dImageMixin.__init__(self)
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties, attProperties=attProperties,
                 bitmap=wx.EmptyBitmap(1, 1), *args, **kwargs)
 
         # Display the picture, if any. This will also initialize the

--- a/dabo/ui/dLabel.py
+++ b/dabo/ui/dLabel.py
@@ -18,8 +18,8 @@ class dLabel(dControlMixin, AlignmentMixin, wx.StaticText):
         self._wordWrap = False
         self._inResizeEvent = False
         self._resetAutoResize = True
-        wxClass = wx.StaticText
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreStaticText
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         self.bindEvent(dEvents.Resize, self.__onResize)
 

--- a/dabo/ui/dLabel.py
+++ b/dabo/ui/dLabel.py
@@ -18,8 +18,8 @@ class dLabel(dControlMixin, AlignmentMixin, wx.StaticText):
         self._wordWrap = False
         self._inResizeEvent = False
         self._resetAutoResize = True
-        preClass = wx.StaticText
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.StaticText
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         self.bindEvent(dEvents.Resize, self.__onResize)
 

--- a/dabo/ui/dLabel.py
+++ b/dabo/ui/dLabel.py
@@ -19,7 +19,7 @@ class dLabel(dControlMixin, AlignmentMixin, wx.StaticText):
         self._inResizeEvent = False
         self._resetAutoResize = True
         preClass = wx.StaticText
-        super(dLabel, self).__init__(preClass, parent=parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         self.bindEvent(dEvents.Resize, self.__onResize)
 

--- a/dabo/ui/dLabel.py
+++ b/dabo/ui/dLabel.py
@@ -18,7 +18,7 @@ class dLabel(dControlMixin, AlignmentMixin, wx.StaticText):
         self._wordWrap = False
         self._inResizeEvent = False
         self._resetAutoResize = True
-        preClass = wx.PreStaticText
+        preClass = wx.StaticText
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         self.bindEvent(dEvents.Resize, self.__onResize)

--- a/dabo/ui/dLine.py
+++ b/dabo/ui/dLine.py
@@ -20,7 +20,7 @@ class dLine(dControlMixin, wx.StaticLine):
         self._baseClass = dLine
         preClass = wx.StaticLine
 
-        super(dLine, self).__init__(preClass, parent=parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dLine.py
+++ b/dabo/ui/dLine.py
@@ -18,9 +18,9 @@ class dLine(dControlMixin, wx.StaticLine):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dLine
-        wxClass = wx.StaticLine
+        preClass = wx.PreStaticLine
 
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dLine.py
+++ b/dabo/ui/dLine.py
@@ -18,9 +18,9 @@ class dLine(dControlMixin, wx.StaticLine):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dLine
-        preClass = wx.StaticLine
+        wxClass = wx.StaticLine
 
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dLine.py
+++ b/dabo/ui/dLine.py
@@ -18,7 +18,7 @@ class dLine(dControlMixin, wx.StaticLine):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dLine
-        preClass = wx.PreStaticLine
+        preClass = wx.StaticLine
 
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)

--- a/dabo/ui/dLinePlot.py
+++ b/dabo/ui/dLinePlot.py
@@ -73,7 +73,7 @@ class _TraceMixin(object):
 class PlotLine(_TraceMixin, plot.PolyLine):
     def __init__(self, *args, **kwargs):
         self._lineStyle = "solid"
-        super(PlotLine, self).__init__(*args, **kwargs)
+        plot.PolyLine.__init__(self, *args, **kwargs)
 
 
     #Property Getters and Setters
@@ -97,7 +97,7 @@ class PlotLine(_TraceMixin, plot.PolyLine):
 class PlotMarkers(_TraceMixin, plot.PolyMarker):
     def __init__(self, *args, **kwargs):
         self._fillStyle = "solid"
-        super(PlotMarkers, self).__init__(*args, **kwargs)
+        plot.PolyMarker.__init__(self, *args, **kwargs)
 
 
     #Property getters and setters
@@ -158,10 +158,10 @@ class dLinePlot(dControlMixin, plot.PlotCanvas):
         self._plotManager = plot.PlotGraphics([])
 
         self._baseClass = dLinePlot
+        plot.PlotCanvas.__init__(self, parent)
         name, _explicitName = self._processName(kwargs, self.__class__.__name__)
-        super(dLinePlot, self).__init__(preClass=None, parent=parent, name=name,
-                properties=properties, attProperties=attProperties,
-                _explicitName=_explicitName, *args, **kwargs)
+        dControlMixin.__init__(self, name, properties=properties,
+                attProperties=attProperties, _explicitName=_explicitName, *args, **kwargs)
 
         self.SetPointLabelFunc(self.DrawPointLabel)
         self.setDefaults()

--- a/dabo/ui/dListBox.py
+++ b/dabo/ui/dListBox.py
@@ -12,8 +12,8 @@ class dListBox(dControlItemMixin, wx.ListBox):
         self._baseClass = dListBox
         self._choices = []
 
-        preClass = wx.ListBox
-        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.ListBox
+        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dListBox.py
+++ b/dabo/ui/dListBox.py
@@ -12,8 +12,8 @@ class dListBox(dControlItemMixin, wx.ListBox):
         self._baseClass = dListBox
         self._choices = []
 
-        wxClass = wx.ListBox
-        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreListBox
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dListBox.py
+++ b/dabo/ui/dListBox.py
@@ -12,7 +12,7 @@ class dListBox(dControlItemMixin, wx.ListBox):
         self._baseClass = dListBox
         self._choices = []
 
-        preClass = wx.PreListBox
+        preClass = wx.ListBox
         dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dListBox.py
+++ b/dabo/ui/dListBox.py
@@ -13,7 +13,7 @@ class dListBox(dControlItemMixin, wx.ListBox):
         self._choices = []
 
         preClass = wx.ListBox
-        super(dListBox, self).__init__(preClass, parent=parent, properties=properties,
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dListControl.py
+++ b/dabo/ui/dListControl.py
@@ -77,7 +77,7 @@ class dListControl(dControlItemMixin,
             style = style | wx.LC_REPORT
         except TypeError:
             style = wx.LC_REPORT
-        preClass = wx.PreListCtrl
+        preClass = wx.ListCtrl
         dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
         ListMixin.ListCtrlAutoWidthMixin.__init__(self)

--- a/dabo/ui/dListControl.py
+++ b/dabo/ui/dListControl.py
@@ -77,8 +77,8 @@ class dListControl(dControlItemMixin,
             style = style | wx.LC_REPORT
         except TypeError:
             style = wx.LC_REPORT
-        wxClass = wx.ListCtrl
-        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreListCtrl
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
         ListMixin.ListCtrlAutoWidthMixin.__init__(self)
         # Dictionary for tracking images by key value
@@ -298,7 +298,7 @@ class dListControl(dControlItemMixin,
             insert = True
         if isinstance(tx, (list, tuple)):
             if insert:
-                new_item = self.InsertItem(row, "")
+                new_item = self.InsertStringItem(row, "")
             currCol = col
             for itm in tx:
                 new_item = self.append(itm, currCol, row)
@@ -308,9 +308,9 @@ class dListControl(dControlItemMixin,
                 if not isinstance(tx, str) and self.AutoConvertToString:
                     tx = "%s" % tx
                 if insert:
-                    new_item = self.InsertItem(row, tx)
+                    new_item = self.InsertStringItem(row, tx)
                 else:
-                    new_item = self.SetItem(row, col, tx)
+                    new_item = self.SetStringItem(row, col, tx)
             else:
                 # should we raise an error? Add the column automatically?
                 pass
@@ -334,7 +334,7 @@ class dListControl(dControlItemMixin,
         Inserts the item at the specified row, or at the beginning if no
         row is specified. Item is inserted at the specified column, as in self.append()
         """
-        self.InsertItem(row, "")
+        self.InsertStringItem(row, "")
         self.append(tx, col, row)
 
 
@@ -528,7 +528,7 @@ class dListControl(dControlItemMixin,
 
     def _listControlSort(self, x, y):
         # Default to standard Python comparison
-        return (x > y) - (x < y)
+        return cmp(x, y)
 
 
     def sort(self, sortFunction=None):

--- a/dabo/ui/dListControl.py
+++ b/dabo/ui/dListControl.py
@@ -77,8 +77,8 @@ class dListControl(dControlItemMixin,
             style = style | wx.LC_REPORT
         except TypeError:
             style = wx.LC_REPORT
-        preClass = wx.ListCtrl
-        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.ListCtrl
+        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
         ListMixin.ListCtrlAutoWidthMixin.__init__(self)
         # Dictionary for tracking images by key value

--- a/dabo/ui/dListControl.py
+++ b/dabo/ui/dListControl.py
@@ -46,8 +46,8 @@ class _ListColumnAccessor(object):
 
 
 
-class dListControl(dControlItemMixin, ListMixin.ListCtrlAutoWidthMixin,
-        wx.ListCtrl):
+class dListControl(dControlItemMixin,
+        ListMixin.ListCtrlAutoWidthMixin, wx.ListCtrl):
     """
     Creates a list control, which is a flexible, virtual list box.
 
@@ -78,8 +78,9 @@ class dListControl(dControlItemMixin, ListMixin.ListCtrlAutoWidthMixin,
         except TypeError:
             style = wx.LC_REPORT
         preClass = wx.ListCtrl
-        super(dListControl, self).__init__(preClass, parent=parent, properties=properties,
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
+        ListMixin.ListCtrlAutoWidthMixin.__init__(self)
         # Dictionary for tracking images by key value
         self.__imageList = {}
         # Need to set this after the superclass call in order to override the default for

--- a/dabo/ui/dMaskedTextBox.py
+++ b/dabo/ui/dMaskedTextBox.py
@@ -83,9 +83,8 @@ class dMaskedTextBox(dTextBoxMixin, masked.TextCtrl):
         kwargs["useFixedWidthFont"] = False
 
         preClass = wx.lib.masked.TextCtrl
-        super(dMaskedTextBox, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def getFormats(cls):

--- a/dabo/ui/dMediaControl.py
+++ b/dabo/ui/dMediaControl.py
@@ -48,9 +48,8 @@ class dMediaControl(dControlMixin, wx.media.MediaCtrl):
         dropHandler = self._extractKey((properties, kwargs), "DroppedFileHandler", self)
         kwargs["DroppedFileHandler"] = dropHandler
 
-        super(dMediaControl, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
         # Create lower-case method names to be consistent with Dabo
 #         self.play = self.Play
         self.pause = self.Pause

--- a/dabo/ui/dMenu.py
+++ b/dabo/ui/dMenu.py
@@ -16,6 +16,9 @@ RadioItemType = wx.ITEM_RADIO
 SeparatorItemType = wx.ITEM_SEPARATOR
 
 
+from dabo.ui.dMenuItem import dMenuItem, dCheckMenuItem, dRadioMenuItem, dSeparatorMenuItem
+
+
 class dMenu(dPemMixin, wx.Menu):
     """
     Creates a menu, which can contain submenus, menu items,
@@ -66,7 +69,7 @@ class dMenu(dPemMixin, wx.Menu):
         the MenuOpen event will not be raised, so trigger on the MenuHighlight
         event instead.
         """
-        if isinstance(self.Parent, dabo.ui.dMenuBar):
+        if isinstance(self.Parent, dabo.ui.dMenuBar.dMenuBar):
             self.bindEvent(dEvents.MenuOpen, self.__onMenuOpenMRU)
         else:
             self.bindEvent(dEvents.MenuHighlight, self.__onMenuOpenMRU)
@@ -128,9 +131,9 @@ class dMenu(dPemMixin, wx.Menu):
         id_ = itm.GetId()
         if id_ == wx.ID_ABOUT:
             # Put the about menu in the App Menu on Mac
-            wx.App_SetMacAboutMenuItemId(id_)
+            wx.PyApp.SetMacAboutMenuItemId(id_)
             cap = daboItem.Parent.Caption
-            wx.App_SetMacHelpMenuTitleName(cap)
+            wx.PyApp.SetMacHelpMenuTitleName(cap)
 
         # Process any 'special' menus
         try:
@@ -140,7 +143,7 @@ class dMenu(dPemMixin, wx.Menu):
         if special == "pref":
             # Put the prefs item in the App Menu on Mac
             self.Parent._mac_pref_menu_item_id = id_
-            wx.App_SetMacPreferencesMenuItemId(id_)
+            wx.PyApp.SetMacPreferencesMenuItemId(id_)
 
 
     def appendItem(self, item):
@@ -228,10 +231,14 @@ class dMenu(dPemMixin, wx.Menu):
             self.insertItem(pos, _item)
             _item.Caption = caption
             return _item
+
+        """
         dummySpacer = None
         if not self.Children:
             dummySpacer = _actualCreation(" ", "", None, "")
             dabo.ui.callAfter(self.remove, dummySpacer)
+        """
+
         item = _actualCreation(caption, help, picture, menutype, *args, **kwargs)
         return item
 
@@ -315,13 +322,11 @@ class dMenu(dPemMixin, wx.Menu):
         except KeyError:
             pass
 
-        if wx.VERSION >= (2,7):
-            # Needed to keep dPemMixin mixed-in in wxPython 2.8
-            val = wx.Menu.RemoveItem(self, item)
-            item.this.own(val.this.own())
-            val.this.disown()
-        else:
-            self.RemoveItem(item)
+        # Needed to keep dPemMixin mixed-in in wxPython 2.8
+        #        val = wx.Menu.RemoveItem(self, item)
+        #        item.this.own(val.this.own())
+        #        val.this.disown()
+        self.Remove(item)
 
         if release:
             item.Destroy()
@@ -388,10 +393,10 @@ class dMenu(dPemMixin, wx.Menu):
             itmSpecial = kwargs.pop("special")
         except KeyError:
             itmSpecial = None
-        cls = {NormalItemType: dabo.ui.dMenuItem,
-                CheckItemType: dabo.ui.dCheckMenuItem,
-                RadioItemType: dabo.ui.dRadioMenuItem,
-                SeparatorItemType: dabo.ui.dSeparatorMenuItem}[itmtyp]
+        cls = {NormalItemType: dMenuItem,
+                CheckItemType: dCheckMenuItem,
+                RadioItemType: dRadioMenuItem,
+                SeparatorItemType: dSeparatorMenuItem}[itmtyp]
         itm = cls(self, HelpText=help, Icon=icon, kind=itmtyp, *args, **kwargs)
         if itmSpecial:
             itm._special = itmSpecial

--- a/dabo/ui/dMenu.py
+++ b/dabo/ui/dMenu.py
@@ -40,7 +40,7 @@ class dMenu(dPemMixin, wx.Menu):
         ##      To work around this, we maintain an internal dictionary that
         ##      maps the id of the wxMenuItem to the dMenuItem object.
         self._daboChildren = {}
-        super(dMenu, self).__init__(preClass, parent=parent, properties=properties,
+        dPemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dMenu.py
+++ b/dabo/ui/dMenu.py
@@ -23,7 +23,7 @@ class dMenu(dPemMixin, wx.Menu):
     """
     def __init__(self, parent=None, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dMenu
-        preClass = None
+        preClass = wx.Menu
         self.Parent = parent
         self._useMRU = self._extractKey(attProperties, "MRU", None)
         if self._useMRU is not None:
@@ -167,7 +167,8 @@ class dMenu(dPemMixin, wx.Menu):
         dummySpacer = None
         if not self.Children:
             dummySpacer = self.append(" ")
-        wxMenuItem = self.AppendMenu(-1, menu.Caption, menu, helpString=menu.HelpText)
+        wxMenuItem = self.AppendMenu(-1, menu.Caption, menu, help=menu.HelpText)
+#-         wxMenuItem = self.AppendSubMenu(menu, menu.Caption, help=menu.HelpText)
         menu._setId(wxMenuItem.GetId())
         menu.Parent = self
         self._daboChildren[wxMenuItem.GetId()] = menu
@@ -178,7 +179,7 @@ class dMenu(dPemMixin, wx.Menu):
 
     def insertMenu(self, pos, menu):
         """Insert a dMenu before the specified position in the menu."""
-        wxMenuItem = self.InsertMenu(pos, -1, menu.Caption, menu, helpString=menu.HelpText)
+        wxMenuItem = self.InsertMenu(pos, -1, menu.Caption, menu, help=menu.HelpText)
         menu._setId(wxMenuItem.GetId())
         menu.Parent = self
         self._daboChildren[wxMenuItem.GetId()] = menu
@@ -187,7 +188,7 @@ class dMenu(dPemMixin, wx.Menu):
 
     def prependMenu(self, menu):
         """Insert a dMenu at the top of the menu."""
-        wxMenuItem = self.PrependMenu(-1, menu.Caption, menu, helpString=menu.HelpText)
+        wxMenuItem = self.PrependMenu(-1, menu.Caption, menu, help=menu.HelpText)
         menu._setId(wxMenuItem.GetId())
         menu.Parent = self
         self._daboChildren[wxMenuItem.GetId()] = menu
@@ -196,7 +197,7 @@ class dMenu(dPemMixin, wx.Menu):
 
     def appendSeparator(self):
         """Insert a separator at the bottom of the menu."""
-        return self._createMenuItem(None, caption=None, HelpText=None, bmp=None, picture=None,
+        return self._createMenuItem(None, caption=None, help=None, bmp=None, picture=None,
                 menutype="separator")
 
 
@@ -210,13 +211,13 @@ class dMenu(dPemMixin, wx.Menu):
         return self.PrependSeparator()
 
 
-    def _createMenuItem(self, pos, caption, HelpText, bmp, picture, menutype, *args, **kwargs):
+    def _createMenuItem(self, pos, caption, help, bmp, picture, menutype, *args, **kwargs):
         """Handles the menu item creation for append(), insert() and prepend()."""
         if pos is None:
             pos = len(self.Children)
         if picture is None:
             picture = bmp
-        def _actualCreation(caption, HelpText, picture, menutype, *args, **kwargs):
+        def _actualCreation(caption, help, picture, menutype, *args, **kwargs):
             if caption:
                 hk = kwargs.get("HotKey", "")
                 if hk:
@@ -224,7 +225,7 @@ class dMenu(dPemMixin, wx.Menu):
                 else:
                     cap = caption
                 kwargs["text"] = cap
-            _item = self._getItem(HelpText, picture, menutype, *args, **kwargs)
+            _item = self._getItem(help, picture, menutype, *args, **kwargs)
             self.insertItem(pos, _item)
             _item.Caption = caption
             return _item
@@ -232,11 +233,11 @@ class dMenu(dPemMixin, wx.Menu):
         if not self.Children:
             dummySpacer = _actualCreation(" ", "", None, "")
             dabo.ui.callAfter(self.remove, dummySpacer)
-        item = _actualCreation(caption, HelpText, picture, menutype, *args, **kwargs)
+        item = _actualCreation(caption, help, picture, menutype, *args, **kwargs)
         return item
 
 
-    def append(self, caption, HelpText="", bmp=None, picture=None,
+    def append(self, caption, help="", bmp=None, picture=None,
             menutype="", *args, **kwargs):
         """
         Append a dMenuItem with the specified properties.
@@ -248,11 +249,11 @@ class dMenu(dPemMixin, wx.Menu):
         of the dMenuItem: if valid property names/values, the dMenuItem will take
         them on; if not valid, an exception will be raised.
         """
-        return self._createMenuItem(None, caption=caption, HelpText=HelpText, bmp=bmp, picture=picture,
+        return self._createMenuItem(None, caption=caption, help=help, bmp=bmp, picture=picture,
                 menutype=menutype, *args, **kwargs)
 
 
-    def insert(self, pos, caption, HelpText="", bmp=None, picture=None,
+    def insert(self, pos, caption, help="", bmp=None, picture=None,
             menutype="", *args, **kwargs):
         """
         Insert a dMenuItem at the given position with the specified properties.
@@ -264,11 +265,11 @@ class dMenu(dPemMixin, wx.Menu):
         of the dMenuItem: if valid property names/values, the dMenuItem will take
         them on; if not valid, an exception will be raised.
         """
-        return self._createMenuItem(pos, caption, HelpText=HelpText, bmp=bmp, picture=picture,
+        return self._createMenuItem(pos, caption, help=help, bmp=bmp, picture=picture,
                 menutype=menutype, *args, **kwargs)
 
 
-    def prepend(self, caption, HelpText="", bmp=None, picture=None,
+    def prepend(self, caption, help="", bmp=None, picture=None,
             menutype="", *args, **kwargs):
         """
         Prepend a dMenuItem with the specified properties.
@@ -280,7 +281,7 @@ class dMenu(dPemMixin, wx.Menu):
         of the dMenuItem: if valid property names/values, the dMenuItem will take
         them on; if not valid, an exception will be raised.
         """
-        return self._createMenuItem(0, caption, HelpText=HelpText, bmp=bmp, picture=picture,
+        return self._createMenuItem(0, caption, help=help, bmp=bmp, picture=picture,
                 menutype=menutype, *args, **kwargs)
 
 
@@ -376,7 +377,7 @@ class dMenu(dPemMixin, wx.Menu):
         return ret
 
 
-    def _getItem(self, HelpText, icon, menutype, *args, **kwargs):
+    def _getItem(self, help, icon, menutype, *args, **kwargs):
         from dabo.ui.dMenuItem import dMenuItem
         from dabo.ui.dMenuItem import dCheckMenuItem
         from dabo.ui.dMenuItem import dRadioMenuItem
@@ -393,8 +394,7 @@ class dMenu(dPemMixin, wx.Menu):
                 CheckItemType: dCheckMenuItem,
                 RadioItemType: dRadioMenuItem,
                 SeparatorItemType: dSeparatorMenuItem}[itmtyp]
-        itm = cls(parent=self, HelpText=HelpText, Icon=icon, kind=itmtyp,
-                *args, **kwargs)
+        itm = cls(self, HelpText=help, Icon=icon, kind=itmtyp, *args, **kwargs)
         if itmSpecial:
             itm._special = itmSpecial
         return itm

--- a/dabo/ui/dMenu.py
+++ b/dabo/ui/dMenu.py
@@ -66,8 +66,7 @@ class dMenu(dPemMixin, wx.Menu):
         the MenuOpen event will not be raised, so trigger on the MenuHighlight
         event instead.
         """
-        from dabo.ui.dMenuBar import dMenuBar
-        if isinstance(self.Parent, dMenuBar):
+        if isinstance(self.Parent, dabo.ui.dMenuBar):
             self.bindEvent(dEvents.MenuOpen, self.__onMenuOpenMRU)
         else:
             self.bindEvent(dEvents.MenuHighlight, self.__onMenuOpenMRU)
@@ -78,8 +77,7 @@ class dMenu(dPemMixin, wx.Menu):
         See the _setMRUBindings method for an explanation. This uses
         the same logic to unbind MRU events.
         """
-        from dabo.ui.dMenuBar import dMenuBar
-        if isinstance(self.Parent, dMenuBar):
+        if isinstance(self.Parent, dabo.ui.dMenuBar):
             self.unbindEvent(dEvents.MenuOpen, self.__onMenuOpenMRU)
         else:
             self.unbindEvent(dEvents.MenuHighlight, self.__onMenuOpenMRU)
@@ -130,9 +128,10 @@ class dMenu(dPemMixin, wx.Menu):
         id_ = itm.GetId()
         if id_ == wx.ID_ABOUT:
             # Put the about menu in the App Menu on Mac
-            wx.PyApp.SetMacPreferencesMenuItemId(id_)
+            wx.App_SetMacAboutMenuItemId(id_)
             cap = daboItem.Parent.Caption
-            wx.PyApp.SetMacHelpMenuTitleName(cap)
+            wx.App_SetMacHelpMenuTitleName(cap)
+
         # Process any 'special' menus
         try:
             special = daboItem._special
@@ -141,24 +140,24 @@ class dMenu(dPemMixin, wx.Menu):
         if special == "pref":
             # Put the prefs item in the App Menu on Mac
             self.Parent._mac_pref_menu_item_id = id_
-            wx.PyApp.SetMacPreferencesMenuItemId(id_)
+            wx.App_SetMacPreferencesMenuItemId(id_)
 
 
     def appendItem(self, item):
         """Insert a dMenuItem at the bottom of the menu."""
-        wxItem = self._getWxItem(self.Append, item)
+        wxItem = self._getWxItem(self.AppendItem, item)
         return item
 
 
     def insertItem(self, pos, item):
         """Insert a dMenuItem before the specified position in the menu."""
-        wxItem = self._getWxItem(self.Insert, item, pos)
+        wxItem = self._getWxItem(self.InsertItem, item, pos)
         return item
 
 
     def prependItem(self, item):
         """Insert a dMenuItem at the top of the menu."""
-        wxItem = self._getWxItem(self.Prepend, item)
+        wxItem = self._getWxItem(self.PrependItem, item)
         return item
 
 
@@ -316,10 +315,13 @@ class dMenu(dPemMixin, wx.Menu):
         except KeyError:
             pass
 
-        # Needed to keep dPemMixin mixed-in in wxPython 2.8
-#        val = wx.Menu.RemoveItem(self, item)
-#        item.this.own(val.this.own())
-#        val.this.disown()
+        if wx.VERSION >= (2,7):
+            # Needed to keep dPemMixin mixed-in in wxPython 2.8
+            val = wx.Menu.RemoveItem(self, item)
+            item.this.own(val.this.own())
+            val.this.disown()
+        else:
+            self.RemoveItem(item)
 
         if release:
             item.Destroy()
@@ -378,10 +380,6 @@ class dMenu(dPemMixin, wx.Menu):
 
 
     def _getItem(self, help, icon, menutype, *args, **kwargs):
-        from dabo.ui.dMenuItem import dMenuItem
-        from dabo.ui.dMenuItem import dCheckMenuItem
-        from dabo.ui.dMenuItem import dRadioMenuItem
-        from dabo.ui.dMenuItem import dSeparatorMenuItem
         itmtyp = self._getItemType(menutype)
         itmid = self._getItemID(menutype)
         if itmid != wx.ID_DEFAULT:
@@ -390,10 +388,10 @@ class dMenu(dPemMixin, wx.Menu):
             itmSpecial = kwargs.pop("special")
         except KeyError:
             itmSpecial = None
-        cls = {NormalItemType: dMenuItem,
-                CheckItemType: dCheckMenuItem,
-                RadioItemType: dRadioMenuItem,
-                SeparatorItemType: dSeparatorMenuItem}[itmtyp]
+        cls = {NormalItemType: dabo.ui.dMenuItem,
+                CheckItemType: dabo.ui.dCheckMenuItem,
+                RadioItemType: dabo.ui.dRadioMenuItem,
+                SeparatorItemType: dabo.ui.dSeparatorMenuItem}[itmtyp]
         itm = cls(self, HelpText=help, Icon=icon, kind=itmtyp, *args, **kwargs)
         if itmSpecial:
             itm._special = itmSpecial

--- a/dabo/ui/dMenuBar.py
+++ b/dabo/ui/dMenuBar.py
@@ -15,11 +15,10 @@ class dMenuBar(dPemMixin, wx.MenuBar):
     which will give you a dMenuBar with the standard File, Edit, and Help
     menus already set up for you.
     """
-    def __init__(self, parent=None, properties=None, *args, **kwargs):
+    def __init__(self, properties=None, *args, **kwargs):
         self._baseClass = dMenuBar
-        preClass = None
-        super(dMenuBar, self).__init__(preClass, parent=parent,
-                properties=properties, *args, **kwargs)
+        wxClass = wx.MenuBar
+        dPemMixin.__init__(self, wxClass, None, properties, *args, **kwargs)
 
 
     def _initEvents(self):

--- a/dabo/ui/dMenuBar.py
+++ b/dabo/ui/dMenuBar.py
@@ -17,8 +17,8 @@ class dMenuBar(dPemMixin, wx.MenuBar):
     """
     def __init__(self, properties=None, *args, **kwargs):
         self._baseClass = dMenuBar
-        wxClass = wx.MenuBar
-        dPemMixin.__init__(self, wxClass, None, properties, *args, **kwargs)
+        preClass = wx.MenuBar
+        dPemMixin.__init__(self, preClass, None, properties, *args, **kwargs)
 
 
     def _initEvents(self):

--- a/dabo/ui/dMenuItem.py
+++ b/dabo/ui/dMenuItem.py
@@ -14,7 +14,7 @@ class dMenuItem(dPemMixin, wx.MenuItem):
     """Creates a menu item, which is usually represented as a string."""
     def __init__(self, parent=None, properties=None, *args, **kwargs):
         self._baseClass = dMenuItem
-        preClass = None
+        wxClass = wx.MenuItem
         self.Parent = parent
 
         ## see comments in _setCaption for explanation of below:
@@ -29,8 +29,7 @@ class dMenuItem(dPemMixin, wx.MenuItem):
         # Holds the unique ID, if any
         self._itemID = None
 
-        super(dMenuItem, self).__init__(preClass, parent, properties, *args,
-                **kwargs)
+        dPemMixin.__init__(self, wxClass, parent, properties, *args, **kwargs)
 
 
     def _initEvents(self):
@@ -215,14 +214,11 @@ class dSeparatorMenuItem(dPemMixin, wx.MenuItem):
     """Creates a menu separator."""
     def __init__(self, parent=None, properties=None, *args, **kwargs):
         self._baseClass = dSeparatorMenuItem
-        preClass = None
+        wxClass = wx.MenuItem
         self.Parent = parent
         # Holds the unique ID, if any
         self._itemID = None
-        # Identify this as a separator
-        kwargs["kind"] = wx.ITEM_SEPARATOR
-        super(dSeparatorMenuItem, self).__init__(preClass, parent=parent,
-                properties=properties, *args, **kwargs)
+        dPemMixin.__init__(self, wxClass, parent, properties, *args, **kwargs)
 
 
     # The following are methods designed to make separators work like other menu items.
@@ -266,7 +262,7 @@ class dSeparatorMenuItem(dPemMixin, wx.MenuItem):
 
 class _AbstractExtendedMenuItem(dMenuItem):
     """Creates a checkbox-like item in a menu."""
-    def __init__(self, preClass, parent=None, properties=None, *args, **kwargs):
+    def __init__(self, parent=None, properties=None, *args, **kwargs):
         # Remove the 'Icon' property, as it interferes with the 'selected' display
         if self.__class__ is _AbstractExtendedMenuItem:
             raise dabo.dException.dException(
@@ -274,7 +270,7 @@ class _AbstractExtendedMenuItem(dMenuItem):
         # Remove the 'Icon' property, as it interferes with the 'selected' display
         self._extractKey((properties, kwargs), "Icon")
         super(_AbstractExtendedMenuItem, self).__init__(parent=parent,
-                properties=properties, *args, **kwargs)
+            properties=properties, *args, **kwargs)
 
 
     def _getChecked(self):
@@ -293,18 +289,10 @@ class _AbstractExtendedMenuItem(dMenuItem):
 
 class dCheckMenuItem(_AbstractExtendedMenuItem):
     """Creates a checkbox-like item in a menu."""
-    def __init__(self, parent=None, properties=None, *args, **kwargs):
-        preClass = None
-        kwargs["kind"] = wx.ITEM_CHECK
-        super(dCheckMenuItem, self).__init__(preClass, parent=parent,
-                properties=properties, *args, **kwargs)
+    pass
 
 
 class dRadioMenuItem(_AbstractExtendedMenuItem):
     """Creates a radiobox-like item in a menu."""
-    def __init__(self, parent=None, properties=None, *args, **kwargs):
-        preClass = None
-        kwargs["kind"] = wx.ITEM_RADIO
-        super(dRadioMenuItem, self).__init__(preClass, parent=parent,
-                properties=properties, *args, **kwargs)
+    pass
 

--- a/dabo/ui/dMenuItem.py
+++ b/dabo/ui/dMenuItem.py
@@ -31,7 +31,6 @@ class dMenuItem(dPemMixin, wx.MenuItem):
 
         dPemMixin.__init__(self, preClass, parent, properties, *args, **kwargs)
 
-
     def _initEvents(self):
         ## wx.MenuItems don't have a Bind() of their own, so this serves to
         ## override the base behavior in dPemMixin._initEvents() which has
@@ -69,7 +68,8 @@ class dMenuItem(dPemMixin, wx.MenuItem):
             cap = "%s\t%s" % (cap, hk)
         curr = self.GetItemLabel()
         ## pkm: On Windows at least, setting the Icon needs to happen before setting the caption.
-        self.SetBitmap(self.Icon)
+        if self.GetKind() == wx.ITEM_NORMAL:
+            self.SetBitmap(self.Icon)
 
         if ustr(cap) != ustr(curr):
             ## Win32 seems to need to clear the caption first, or funkiness
@@ -174,6 +174,9 @@ class dMenuItem(dPemMixin, wx.MenuItem):
 
     def _setParent(self, val):
         self._parent = val
+
+
+
 
 
     Caption = property(_getCaption, _setCaption, None,

--- a/dabo/ui/dMenuItem.py
+++ b/dabo/ui/dMenuItem.py
@@ -14,7 +14,7 @@ class dMenuItem(dPemMixin, wx.MenuItem):
     """Creates a menu item, which is usually represented as a string."""
     def __init__(self, parent=None, properties=None, *args, **kwargs):
         self._baseClass = dMenuItem
-        wxClass = wx.MenuItem
+        preClass = wx.MenuItem
         self.Parent = parent
 
         ## see comments in _setCaption for explanation of below:
@@ -29,7 +29,7 @@ class dMenuItem(dPemMixin, wx.MenuItem):
         # Holds the unique ID, if any
         self._itemID = None
 
-        dPemMixin.__init__(self, wxClass, parent, properties, *args, **kwargs)
+        dPemMixin.__init__(self, preClass, parent, properties, *args, **kwargs)
 
 
     def _initEvents(self):
@@ -214,11 +214,11 @@ class dSeparatorMenuItem(dPemMixin, wx.MenuItem):
     """Creates a menu separator."""
     def __init__(self, parent=None, properties=None, *args, **kwargs):
         self._baseClass = dSeparatorMenuItem
-        wxClass = wx.MenuItem
+        preClass = wx.MenuItem
         self.Parent = parent
         # Holds the unique ID, if any
         self._itemID = None
-        dPemMixin.__init__(self, wxClass, parent, properties, *args, **kwargs)
+        dPemMixin.__init__(self, preClass, parent, properties, *args, **kwargs)
 
 
     # The following are methods designed to make separators work like other menu items.

--- a/dabo/ui/dMessageBox.py
+++ b/dabo/ui/dMessageBox.py
@@ -31,7 +31,7 @@ class dMessageBox(wx.MessageDialog):
         # Force the message and title to strings
         message = "%s" % message
         title = "%s" % title
-        super(dMessageBox, self).__init__(parent, message, title, style)
+        wx.MessageDialog.__init__(self, parent, message, title, style)
 
 
 def areYouSure(message="Are you sure?", title=None, defaultNo=False,

--- a/dabo/ui/dNumericBox.py
+++ b/dabo/ui/dNumericBox.py
@@ -66,8 +66,8 @@ class dNumericBox(dTextBoxMixin, masked.NumCtrl):
             fontFace = "Lucida Grande"
         if fontFace:
              kwargs["FontFace"] = fontFace
-        super(dNumericBox, self).__init__(masked.NumCtrl, parent=parent,
-                properties, attProperties, *args, **kwargs)
+        dTextBoxMixin.__init__(self, masked.NumCtrl, parent, properties,
+                attProperties, *args, **kwargs)
 
     #--- Public interface.
 

--- a/dabo/ui/dPageFrame.py
+++ b/dabo/ui/dPageFrame.py
@@ -52,9 +52,9 @@ class dPageFrame(dPageFrameMixin, wx.Notebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageFrame
-        preClass = wx.Notebook
+        wxClass = wx.Notebook
 
-        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def _afterInit(self):
@@ -74,9 +74,9 @@ class dPageToolBar(dPageFrameMixin, wx.Toolbook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageToolBar
-        preClass = wx.Toolbook
+        wxClass = wx.Toolbook
 
-        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def _afterInit(self):
@@ -130,10 +130,10 @@ class dPageList(dPageFrameMixin, wx.Listbook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageList
-        preClass = wx.Listbook
+        wxClass = wx.Listbook
         # Dictionary for tracking images by key value
         self._imageList = {}
-        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
         self.Bind(wx.EVT_LIST_ITEM_MIDDLE_CLICK, self.__onWxMiddleClick)
@@ -191,8 +191,8 @@ class dPageSelect(dPageFrameMixin, wx.Choicebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageSelect
-        preClass = wx.Choicebook
-        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.Choicebook
+        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         # Dictionary for tracking images by key value
         self._imageList = {}
@@ -225,7 +225,7 @@ class dDockTabs(dPageFrameMixin, aui.AuiNotebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dDockTabs
-        preClass = aui.AuiNotebook
+        wxClass = aui.AuiNotebook
 
         newStyle = (aui.AUI_NB_TOP | aui.AUI_NB_SCROLL_BUTTONS)
         self._movableTabs = self._extractKey((properties, attProperties, kwargs), "MovableTabs", True)
@@ -238,7 +238,7 @@ class dDockTabs(dPageFrameMixin, aui.AuiNotebook):
             kwargs["agwStyle"] = newStyle
         else:
             kwargs["style"] = newStyle
-        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -308,13 +308,13 @@ if _USE_FLAT:
 
         def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
             self._baseClass = dPageStyled
-            preClass = fnb.FlatNotebook
+            wxClass = fnb.FlatNotebook
             # For some reason this class always opens to the *last* page, unlike all other
             # paged controls. This will make it open to the first page, unless otherwise
             # explicitly set.
             selpg = int(self._extractKey((properties, attProperties, kwargs), "SelectedPageNumber",
                     defaultVal=0))
-            dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+            dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
                     attProperties=attProperties, *args, **kwargs)
             dui.setAfter(self, "SelectedPageNumber", selpg)
 

--- a/dabo/ui/dPageFrame.py
+++ b/dabo/ui/dPageFrame.py
@@ -52,7 +52,7 @@ class dPageFrame(dPageFrameMixin, wx.Notebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageFrame
-        preClass = wx.PreNotebook
+        preClass = wx.Notebook
 
         dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
@@ -74,7 +74,7 @@ class dPageToolBar(dPageFrameMixin, wx.Toolbook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageToolBar
-        preClass = wx.PreToolbook
+        preClass = wx.Toolbook
 
         dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
@@ -130,7 +130,7 @@ class dPageList(dPageFrameMixin, wx.Listbook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageList
-        preClass = wx.PreListbook
+        preClass = wx.Listbook
         # Dictionary for tracking images by key value
         self._imageList = {}
         dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
@@ -191,7 +191,7 @@ class dPageSelect(dPageFrameMixin, wx.Choicebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageSelect
-        preClass = wx.PreChoicebook
+        preClass = wx.Choicebook
         dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         # Dictionary for tracking images by key value

--- a/dabo/ui/dPageFrame.py
+++ b/dabo/ui/dPageFrame.py
@@ -17,18 +17,21 @@ except ImportError:
     import wx.aui as aui
     _USE_AGW = False
 
-#The Editra flatnotebook module takes care of the Nav Buttons and Dropdown Tab List
-#overlap problem, so we try to import that module first.  If that doesn't
-#Why wxPython doesn't fold this flatnotebook module into the main one is beyond me...
-try:
-    import wx.tools.Editra.src.extern.flatnotebook as fnb
-    _USE_EDITRA = True
-except ImportError:
-    if (wx.VERSION >= (2, 8, 9, 2)):
-        import wx.lib.agw.flatnotebook as fnb
-    else:
-        import wx.lib.flatnotebook as fnb
-    _USE_EDITRA = False
+#The flatnotebook version we need is not avialable with wxPython < 2.8.4
+_USE_FLAT = (wx.VERSION >= (2, 8, 4))
+if _USE_FLAT:
+    #The Editra flatnotebook module takes care of the Nav Buttons and Dropdown Tab List
+    #overlap problem, so we try to import that module first.  If that doesn't
+    #Why wxPython doesn't fold this flatnotebook module into the main one is beyond me...
+    try:
+        import wx.tools.Editra.src.extern.flatnotebook as fnb
+        _USE_EDITRA = True
+    except ImportError:
+        if (wx.VERSION >= (2, 8, 9, 2)):
+            import wx.lib.agw.flatnotebook as fnb
+        else:
+            import wx.lib.flatnotebook as fnb
+        _USE_EDITRA = False
 
 
 def readonly(value):
@@ -51,9 +54,8 @@ class dPageFrame(dPageFrameMixin, wx.Notebook):
         self._baseClass = dPageFrame
         preClass = wx.Notebook
 
-        super(dPageFrame, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
     def _afterInit(self):
         if sys.platform[:3] == "win":
@@ -74,9 +76,8 @@ class dPageToolBar(dPageFrameMixin, wx.Toolbook):
         self._baseClass = dPageToolBar
         preClass = wx.Toolbook
 
-        super(dPageToolBar, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
     def _afterInit(self):
         if sys.platform[:3] == "win":
@@ -132,9 +133,8 @@ class dPageList(dPageFrameMixin, wx.Listbook):
         preClass = wx.Listbook
         # Dictionary for tracking images by key value
         self._imageList = {}
-        super(dPageList, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         self.Bind(wx.EVT_LIST_ITEM_MIDDLE_CLICK, self.__onWxMiddleClick)
         self.Bind(wx.EVT_LIST_ITEM_RIGHT_CLICK, self.__onWxRightClick)
@@ -192,9 +192,8 @@ class dPageSelect(dPageFrameMixin, wx.Choicebook):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageSelect
         preClass = wx.Choicebook
-        super(dPageSelect, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
         # Dictionary for tracking images by key value
         self._imageList = {}
 
@@ -239,9 +238,8 @@ class dDockTabs(dPageFrameMixin, aui.AuiNotebook):
             kwargs["agwStyle"] = newStyle
         else:
             kwargs["style"] = newStyle
-        super(dDockTabs, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def insertPage(self, pos, pgCls=None, caption="", imgKey=None,
@@ -297,369 +295,369 @@ class dDockTabs(dPageFrameMixin, aui.AuiNotebook):
 
 
 
-class dPageStyled(dPageFrameMixin, fnb.FlatNotebook):
-    """
-    Creates a pageframe, which can contain an unlimited number of pages,
-    each of which should be a subclass/instance of the dPage class. Note that there
-    is no visible border around the pages.
-    """
-    _evtPageChanged = readonly(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGED)
-    _evtPageChanging = readonly(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGING)
-    _tabposBottom = readonly(fnb.FNB_BOTTOM)
+if _USE_FLAT:
+    class dPageStyled(dPageFrameMixin, fnb.FlatNotebook):
+        """
+        Creates a pageframe, which can contain an unlimited number of pages,
+        each of which should be a subclass/instance of the dPage class. Note that there
+        is no visible border around the pages.
+        """
+        _evtPageChanged = readonly(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGED)
+        _evtPageChanging = readonly(fnb.EVT_FLATNOTEBOOK_PAGE_CHANGING)
+        _tabposBottom = readonly(fnb.FNB_BOTTOM)
 
-    def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
-        self._baseClass = dPageStyled
-        preClass = fnb.FlatNotebook
-        # For some reason this class always opens to the *last* page, unlike all other
-        # paged controls. This will make it open to the first page, unless otherwise
-        # explicitly set.
-        selpg = int(self._extractKey((properties, attProperties, kwargs), "SelectedPageNumber",
-                defaultVal=0))
-        super(dPageStyled, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
-        dui.setAfter(self, "SelectedPageNumber", selpg)
-
-
-    def _initEvents(self):
-        super(dPageStyled, self)._initEvents()
-        self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.__onPageClosing)
-        self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CLOSED, self.__onPageClosed)
-        self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CONTEXT_MENU, self.__onPageContextMenu)
+        def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
+            self._baseClass = dPageStyled
+            preClass = fnb.FlatNotebook
+            # For some reason this class always opens to the *last* page, unlike all other
+            # paged controls. This will make it open to the first page, unless otherwise
+            # explicitly set.
+            selpg = int(self._extractKey((properties, attProperties, kwargs), "SelectedPageNumber",
+                    defaultVal=0))
+            dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
+                    attProperties=attProperties, *args, **kwargs)
+            dui.setAfter(self, "SelectedPageNumber", selpg)
 
 
-    def _afterInit(self):
-        if sys.platform[:3] == "win":
-            ## This keeps Pages from being ugly on Windows:
-            self.SetBackgroundColour(self.GetBackgroundColour())
-        super(dPageStyled, self)._afterInit()
+        def _initEvents(self):
+            super(dPageStyled, self)._initEvents()
+            self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CLOSING, self.__onPageClosing)
+            self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CLOSED, self.__onPageClosed)
+            self.Bind(fnb.EVT_FLATNOTEBOOK_PAGE_CONTEXT_MENU, self.__onPageContextMenu)
 
 
-    def __onPageClosing(self, evt):
-        """The page has not yet been closed, so we can veto it if conditions call for it."""
-        pageNum = evt.GetSelection()
-        if self._beforePageClose(pageNum) is False:
-            evt.Veto()
-        else:
-            evt.Skip()
-        self.raiseEvent(dEvents.PageClosing, pageNum=pageNum)
+        def _afterInit(self):
+            if sys.platform[:3] == "win":
+                ## This keeps Pages from being ugly on Windows:
+                self.SetBackgroundColour(self.GetBackgroundColour())
+            super(dPageStyled, self)._afterInit()
 
 
-    def _beforePageClose(self, page):
-        return self.beforePageClose(page)
-
-
-    def insertPage(self, *args, **kwargs):
-        page = super(dPageStyled, self).insertPage(*args, **kwargs)
-        # incline isn't autoset on new page add so set it
-        self.SetAllPagesShapeAngle(self.TabSideIncline)
-        return page
-
-
-    def beforePageClose(self, page):
-        """Return False from this method to prevent the page from closing."""
-        pass
-
-
-    def __onPageClosed(self, evt):
-        self.raiseEvent(dEvents.PageClosed)
-
-
-    def __onPageContextMenu(self, evt):
-        self.GetPage(self.GetSelection()).raiseEvent(dEvents.PageContextMenu)
-
-
-    #Property getters and setters
-    def _getActiveTabColor(self):
-        try:
-            ret = self._activeTabColor
-        except AttributeError:
-            ret = self._activeTabColor = None
-        return ret
-
-    def _setActiveTabColor(self, val):
-        if self._constructed():
-            self._activeTabColor = val
-            if isinstance(val, str):
-                val = dColors.colorTupleFromName(val)
-            if isinstance(val, tuple):
-                self.SetActiveTabColour(wx.Colour(*val))
-                self.Refresh()
+        def __onPageClosing(self, evt):
+            """The page has not yet been closed, so we can veto it if conditions call for it."""
+            pageNum = evt.GetSelection()
+            if self._beforePageClose(pageNum) is False:
+                evt.Veto()
             else:
-                raise ValueError(_("'%s' can not be translated into a color" % val))
-        else:
-            self._properties["ActiveTabColor"] = val
+                evt.Skip()
+            self.raiseEvent(dEvents.PageClosing, pageNum=pageNum)
 
 
-    def _getActiveTabTextColor(self):
-        try:
-            ret = self._activeTabTextColor
-        except AttributeError:
-            ret = self._activeTabTextColor = None
-        return ret
-
-    def _setActiveTabTextColor(self, val):
-        if self._constructed():
-            self._activeTabTextColor = val
-            if isinstance(val, str):
-                val = dColors.colorTupleFromName(val)
-            if isinstance(val, tuple):
-                self.SetActiveTabTextColour(wx.Colour(*val))
-                self.Refresh()
-            else:
-                raise ValueError(_("'%s' can not be translated into a color" % val))
-        else:
-            self._properties["ActiveTabTextColor"] = val
+        def _beforePageClose(self, page):
+            return self.beforePageClose(page)
 
 
-    def _getInactiveTabTextColor(self):
-        try:
-            ret = self._inactiveTabTextColor
-        except AttributeError:
-            ret = self._inactiveTabTextColor = None
-        return ret
-
-    def _setInactiveTabTextColor(self, val):
-        if self._constructed():
-            self._inactiveTabTextColor = val
-            if isinstance(val, str):
-                val = dColors.colorTupleFromName(val)
-            if isinstance(val, tuple):
-                self.SetNonActiveTabTextColour(wx.Colour(*val))
-                self.Refresh()
-            else:
-                raise ValueError(_("'%s' can not be translated into a color" % val))
-        else:
-            self._properties["InactiveTabTextColor"] = val
+        def insertPage(self, *args, **kwargs):
+            page = super(dPageStyled, self).insertPage(*args, **kwargs)
+            # incline isn't autoset on new page add so set it
+            self.SetAllPagesShapeAngle(self.TabSideIncline)
+            return page
 
 
-    def _getTabAreaColor(self):
-        try:
-            ret = self._tabAreaColor
-        except AttributeError:
-            ret = self._tabAreaColor = None
-        return ret
-
-    def _setTabAreaColor(self, val):
-        if self._constructed():
-            self._tabAreaColor = val
-            if isinstance(val, str):
-                val = dColors.colorTupleFromName(val)
-            if isinstance(val, tuple):
-                self.SetTabAreaColour(wx.Colour(*val))
-                self.Refresh()
-            else:
-                raise ValueError(_("'%s' can not be translated into a color" % val))
-        else:
-            self._properties["MenuBackColor"] = val
-
-
-    def _getShowDropdownTabList(self):
-        try:
-            ret = self._showDropdownTabList
-        except AttributeError:
-            ret = self._showDropdownTabList = False
-        return ret
-
-    def _setShowDropdownTabList(self, val):
-        val = bool(val)
-        if val:
-            self._addWindowStyleFlag(fnb.FNB_DROPDOWN_TABS_LIST)
-            if not _USE_EDITRA:
-                self._addWindowStyleFlag(fnb.FNB_NO_NAV_BUTTONS)
-                self._showNavButtons = False
-        else:
-            self._delWindowStyleFlag(fnb.FNB_DROPDOWN_TABS_LIST)
-
-        self._showDropdownTabList = val
-
-
-    def _getShowMenuCloseButton(self):
-        try:
-            ret = self._showMenuCloseButton
-        except AttributeError:
-            ret = self._showMenuCloseButton = True
-        return ret
-
-    def _setShowMenuCloseButton(self, val):
-        val = bool(val)
-        if val:
-            self._delWindowStyleFlag(fnb.FNB_NO_X_BUTTON)
-        else:
-            self._addWindowStyleFlag(fnb.FNB_NO_X_BUTTON)
-        self._showMenuCloseButton = val
-
-
-    def _getShowMenuOnSingleTab(self):
-        try:
-            ret = self._showMenuOnSingleTab
-        except AttributeError:
-            ret = self._showMenuOnSingleTab = True
-        return ret
-
-    def _setShowMenuOnSingleTab(self, val):
-        val = bool(val)
-        if val:
-            self._delWindowStyleFlag(fnb.FNB_HIDE_ON_SINGLE_TAB)
-        else:
-            self._addWindowStyleFlag(fnb.FNB_HIDE_ON_SINGLE_TAB)
-        self._showMenuOnSingleTab = val
-
-
-    def _getShowNavButtons(self):
-        try:
-            ret = self._showNavButtons
-        except AttributeError:
-            ret = self._showNavButtons = True
-        return ret
-
-    def _setShowNavButtons(self, val):
-        val = bool(val)
-        if val:
-            self._delWindowStyleFlag(fnb.FNB_NO_NAV_BUTTONS)
-            if not _USE_EDITRA:
-                self._delWindowStyleFlag(fnb.FNB_DROPDOWN_TABS_LIST)
-                self._showDropdownTabList = False
-        else:
-            self._addWindowStyleFlag(fnb.FNB_NO_NAV_BUTTONS)
-        self._showNavButtons = val
-
-
-    def _getShowPageCloseButtons(self):
-        try:
-            ret = self._showPageCloseButtons
-        except AttributeError:
-            ret = self._showPageCloseButtons = False
-        return ret
-
-    def _setShowPageCloseButtons(self, val):
-        val = bool(val)
-        if val:
-            self._addWindowStyleFlag(fnb.FNB_X_ON_TAB)
-        else:
-            self._delWindowStyleFlag(fnb.FNB_X_ON_TAB)
-        self._showPageCloseButtons = val
-
-
-    def _getTabPosition(self):
-        if self._hasWindowStyleFlag(self._tabposBottom):
-            return "Bottom"
-        else:
-            return "Top"
-
-    def _setTabPosition(self, val):
-        lowval = ustr(val).lower()[0]
-        self._delWindowStyleFlag(self._tabposBottom)
-
-        if lowval == "t":
+        def beforePageClose(self, page):
+            """Return False from this method to prevent the page from closing."""
             pass
-        elif lowval == "b":
-            self._addWindowStyleFlag(self._tabposBottom)
-        else:
-            raise ValueError(_("The only possible values are 'Top' and 'Bottom'"))
 
 
-    def _getTabSideIncline(self):
-        try:
-            ret = self._tabSideIncline
-        except AttributeError:
-            ret = self._tabSideIncline = 0
-        return ret
-
-    def _setTabSideIncline(self, val):
-        val = int(val)
-        if not (0 <= val <= 15):
-            raise ValueError(_("Value must be 0 through 15"))
-        self._tabSideIncline = val
-        self.SetAllPagesShapeAngle(val)
+        def __onPageClosed(self, evt):
+            self.raiseEvent(dEvents.PageClosed)
 
 
-    def _getTabStyle(self):
-        try:
-            ret = self._tabStyle
-        except AttributeError:
-            ret = self._tabStyle = "Default"
-        return ret
-
-    def _setTabStyle(self, val):
-        self._delWindowStyleFlag(fnb.FNB_VC8)
-        self._delWindowStyleFlag(fnb.FNB_VC71)
-        self._delWindowStyleFlag(fnb.FNB_FANCY_TABS)
-        self._delWindowStyleFlag(fnb.FNB_FF2)
-        lowval = ustr(val).lower()
-        flags = {"default": "", "vc8": fnb.FNB_VC8, "vc71": fnb.FNB_VC71,
-                "fancy": fnb.FNB_FANCY_TABS, "firefox": fnb.FNB_FF2}
-        cleanStyles = {"default": "Default", "vc8": "VC8", "vc71": "VC71",
-                "fancy": "Fancy", "firefox": "Firefox"}
-        try:
-            flagToSet = flags[lowval]
-            self._tabStyle = cleanStyles[lowval]
-        except KeyError:
-            raise ValueError(_("The only possible values are 'Default' and 'VC8', 'VC71', 'Fancy', or 'Firefox'"))
-        if flagToSet:
-            self._addWindowStyleFlag(flagToSet)
+        def __onPageContextMenu(self, evt):
+            self.GetPage(self.GetSelection()).raiseEvent(dEvents.PageContextMenu)
 
 
-    #Property definitions
-    ActiveTabColor = property(_getActiveTabColor, _setActiveTabColor, None,
-            _("""Specifies the color of the active tab (str or 3-tuple) (Default=None)
-            Note: is not visible with the 'VC8' TabStyle"""))
+        #Property getters and setters
+        def _getActiveTabColor(self):
+            try:
+                ret = self._activeTabColor
+            except AttributeError:
+                ret = self._activeTabColor = None
+            return ret
 
-    ActiveTabTextColor = property(_getActiveTabTextColor, _setActiveTabTextColor, None,
-            _("""Specifies the color of the text of the active tab (str or 3-tuple) (Default=None)
-            Note: is not visible with the 'VC8' TabStyle"""))
+        def _setActiveTabColor(self, val):
+            if self._constructed():
+                self._activeTabColor = val
+                if isinstance(val, str):
+                    val = dColors.colorTupleFromName(val)
+                if isinstance(val, tuple):
+                    self.SetActiveTabColour(wx.Colour(*val))
+                    self.Refresh()
+                else:
+                    raise ValueError(_("'%s' can not be translated into a color" % val))
+            else:
+                self._properties["ActiveTabColor"] = val
 
-    InactiveTabTextColor = property(_getInactiveTabTextColor, _setInactiveTabTextColor, None,
-            _("""Specifies the color of the text of non active tabs (str or 3-tuple) (Default=None)
-            Note: is not visible with the 'VC8' TabStyle"""))
 
-    MenuBackColor = property(_getTabAreaColor, _setTabAreaColor, None,
-            _("""Specifies the background color of the tab area. This is exactly the same as
-            the 'TabAreaColor' property, but is maintained for backwards compatibility.
-            Default = None.  (str or 3-tuple) Note: is not visible with 'VC71' TabStyle."""))
+        def _getActiveTabTextColor(self):
+            try:
+                ret = self._activeTabTextColor
+            except AttributeError:
+                ret = self._activeTabTextColor = None
+            return ret
 
-    ShowDropdownTabList = property(_getShowDropdownTabList, _setShowDropdownTabList, None,
-            _("""Specifies whether the dropdown tab list button is visible in the menu (bool) (Default=False)
-            Setting this property to True will set ShowNavButtons to False"""))
+        def _setActiveTabTextColor(self, val):
+            if self._constructed():
+                self._activeTabTextColor = val
+                if isinstance(val, str):
+                    val = dColors.colorTupleFromName(val)
+                if isinstance(val, tuple):
+                    self.SetActiveTabTextColour(wx.Colour(*val))
+                    self.Refresh()
+                else:
+                    raise ValueError(_("'%s' can not be translated into a color" % val))
+            else:
+                self._properties["ActiveTabTextColor"] = val
 
-    ShowMenuCloseButton = property(_getShowMenuCloseButton, _setShowMenuCloseButton, None,
-            _("Specifies whether the close button is visible in the menu (bool) (Default=True)"))
 
-    ShowMenuOnSingleTab = property(_getShowMenuOnSingleTab, _setShowMenuOnSingleTab, None,
-            _("Specifies whether the tab thumbs and nav buttons are shown when there is a single tab. (bool) (Default=True)"))
+        def _getInactiveTabTextColor(self):
+            try:
+                ret = self._inactiveTabTextColor
+            except AttributeError:
+                ret = self._inactiveTabTextColor = None
+            return ret
 
-    ShowNavButtons = property(_getShowNavButtons, _setShowNavButtons, None,
-            _("""Specifies whether the left and right nav buttons are visible in the menu (bool) (Default=True)
-            Setting this property to True will set ShowDropdownTabList to False"""))
+        def _setInactiveTabTextColor(self, val):
+            if self._constructed():
+                self._inactiveTabTextColor = val
+                if isinstance(val, str):
+                    val = dColors.colorTupleFromName(val)
+                if isinstance(val, tuple):
+                    self.SetNonActiveTabTextColour(wx.Colour(*val))
+                    self.Refresh()
+                else:
+                    raise ValueError(_("'%s' can not be translated into a color" % val))
+            else:
+                self._properties["InactiveTabTextColor"] = val
 
-    ShowPageCloseButtons = property(_getShowPageCloseButtons, _setShowPageCloseButtons, None,
-            _("Specifies whether the close button is visible on the page tab (bool) (Default=False)"))
 
-    TabAreaColor = property(_getTabAreaColor, _setTabAreaColor, None,
-            _("""Specifies the background color of the tab area. This is exactly the same as
-            the 'MenuBackColor' property, but with a more intuitive name.  (str or 3-tuple)
-            (Default=None) Note: is not visible with 'VC71' TabStyle."""))
+        def _getTabAreaColor(self):
+            try:
+                ret = self._tabAreaColor
+            except AttributeError:
+                ret = self._tabAreaColor = None
+            return ret
 
-    TabPosition = property(_getTabPosition, _setTabPosition, None,
-            _("""Specifies where the page tabs are located. (string)
-                Top (default)
-                Bottom
-                """) )
+        def _setTabAreaColor(self, val):
+            if self._constructed():
+                self._tabAreaColor = val
+                if isinstance(val, str):
+                    val = dColors.colorTupleFromName(val)
+                if isinstance(val, tuple):
+                    self.SetTabAreaColour(wx.Colour(*val))
+                    self.Refresh()
+                else:
+                    raise ValueError(_("'%s' can not be translated into a color" % val))
+            else:
+                self._properties["MenuBackColor"] = val
 
-    TabSideIncline = property(_getTabSideIncline, _setTabSideIncline, None,
-            _("""Specifies the incline of the sides of the tab in degrees (int) (Default=0)
-                Acceptable values are 0  - 15.
-                Note: this property will have no effect on TabStyles other than Default.
-                """))
 
-    TabStyle = property(_getTabStyle, _setTabStyle, None,
-            _("""Specifies the style of the display tabs. (string)
-                "Default" (default)
-                "VC8"
-                "VC71"
-                "Fancy"
-                "Firefox"
-                """))
+        def _getShowDropdownTabList(self):
+            try:
+                ret = self._showDropdownTabList
+            except AttributeError:
+                ret = self._showDropdownTabList = False
+            return ret
+
+        def _setShowDropdownTabList(self, val):
+            val = bool(val)
+            if val:
+                self._addWindowStyleFlag(fnb.FNB_DROPDOWN_TABS_LIST)
+                if not _USE_EDITRA:
+                    self._addWindowStyleFlag(fnb.FNB_NO_NAV_BUTTONS)
+                    self._showNavButtons = False
+            else:
+                self._delWindowStyleFlag(fnb.FNB_DROPDOWN_TABS_LIST)
+
+            self._showDropdownTabList = val
+
+
+        def _getShowMenuCloseButton(self):
+            try:
+                ret = self._showMenuCloseButton
+            except AttributeError:
+                ret = self._showMenuCloseButton = True
+            return ret
+
+        def _setShowMenuCloseButton(self, val):
+            val = bool(val)
+            if val:
+                self._delWindowStyleFlag(fnb.FNB_NO_X_BUTTON)
+            else:
+                self._addWindowStyleFlag(fnb.FNB_NO_X_BUTTON)
+            self._showMenuCloseButton = val
+
+
+        def _getShowMenuOnSingleTab(self):
+            try:
+                ret = self._showMenuOnSingleTab
+            except AttributeError:
+                ret = self._showMenuOnSingleTab = True
+            return ret
+
+        def _setShowMenuOnSingleTab(self, val):
+            val = bool(val)
+            if val:
+                self._delWindowStyleFlag(fnb.FNB_HIDE_ON_SINGLE_TAB)
+            else:
+                self._addWindowStyleFlag(fnb.FNB_HIDE_ON_SINGLE_TAB)
+            self._showMenuOnSingleTab = val
+
+
+        def _getShowNavButtons(self):
+            try:
+                ret = self._showNavButtons
+            except AttributeError:
+                ret = self._showNavButtons = True
+            return ret
+
+        def _setShowNavButtons(self, val):
+            val = bool(val)
+            if val:
+                self._delWindowStyleFlag(fnb.FNB_NO_NAV_BUTTONS)
+                if not _USE_EDITRA:
+                    self._delWindowStyleFlag(fnb.FNB_DROPDOWN_TABS_LIST)
+                    self._showDropdownTabList = False
+            else:
+                self._addWindowStyleFlag(fnb.FNB_NO_NAV_BUTTONS)
+            self._showNavButtons = val
+
+
+        def _getShowPageCloseButtons(self):
+            try:
+                ret = self._showPageCloseButtons
+            except AttributeError:
+                ret = self._showPageCloseButtons = False
+            return ret
+
+        def _setShowPageCloseButtons(self, val):
+            val = bool(val)
+            if val:
+                self._addWindowStyleFlag(fnb.FNB_X_ON_TAB)
+            else:
+                self._delWindowStyleFlag(fnb.FNB_X_ON_TAB)
+            self._showPageCloseButtons = val
+
+
+        def _getTabPosition(self):
+            if self._hasWindowStyleFlag(self._tabposBottom):
+                return "Bottom"
+            else:
+                return "Top"
+
+        def _setTabPosition(self, val):
+            lowval = ustr(val).lower()[0]
+            self._delWindowStyleFlag(self._tabposBottom)
+
+            if lowval == "t":
+                pass
+            elif lowval == "b":
+                self._addWindowStyleFlag(self._tabposBottom)
+            else:
+                raise ValueError(_("The only possible values are 'Top' and 'Bottom'"))
+
+
+        def _getTabSideIncline(self):
+            try:
+                ret = self._tabSideIncline
+            except AttributeError:
+                ret = self._tabSideIncline = 0
+            return ret
+
+        def _setTabSideIncline(self, val):
+            val = int(val)
+            if not (0 <= val <= 15):
+                raise ValueError(_("Value must be 0 through 15"))
+            self._tabSideIncline = val
+            self.SetAllPagesShapeAngle(val)
+
+
+        def _getTabStyle(self):
+            try:
+                ret = self._tabStyle
+            except AttributeError:
+                ret = self._tabStyle = "Default"
+            return ret
+
+        def _setTabStyle(self, val):
+            self._delWindowStyleFlag(fnb.FNB_VC8)
+            self._delWindowStyleFlag(fnb.FNB_VC71)
+            self._delWindowStyleFlag(fnb.FNB_FANCY_TABS)
+            self._delWindowStyleFlag(fnb.FNB_FF2)
+            lowval = ustr(val).lower()
+            flags = {"default": "", "vc8": fnb.FNB_VC8, "vc71": fnb.FNB_VC71,
+                    "fancy": fnb.FNB_FANCY_TABS, "firefox": fnb.FNB_FF2}
+            cleanStyles = {"default": "Default", "vc8": "VC8", "vc71": "VC71",
+                    "fancy": "Fancy", "firefox": "Firefox"}
+            try:
+                flagToSet = flags[lowval]
+                self._tabStyle = cleanStyles[lowval]
+            except KeyError:
+                raise ValueError(_("The only possible values are 'Default' and 'VC8', 'VC71', 'Fancy', or 'Firefox'"))
+            if flagToSet:
+                self._addWindowStyleFlag(flagToSet)
+
+
+        #Property definitions
+        ActiveTabColor = property(_getActiveTabColor, _setActiveTabColor, None,
+                _("""Specifies the color of the active tab (str or 3-tuple) (Default=None)
+                Note: is not visible with the 'VC8' TabStyle"""))
+
+        ActiveTabTextColor = property(_getActiveTabTextColor, _setActiveTabTextColor, None,
+                _("""Specifies the color of the text of the active tab (str or 3-tuple) (Default=None)
+                Note: is not visible with the 'VC8' TabStyle"""))
+
+        InactiveTabTextColor = property(_getInactiveTabTextColor, _setInactiveTabTextColor, None,
+                _("""Specifies the color of the text of non active tabs (str or 3-tuple) (Default=None)
+                Note: is not visible with the 'VC8' TabStyle"""))
+
+        MenuBackColor = property(_getTabAreaColor, _setTabAreaColor, None,
+                _("""Specifies the background color of the tab area. This is exactly the same as
+                the 'TabAreaColor' property, but is maintained for backwards compatibility.
+                Default = None.  (str or 3-tuple) Note: is not visible with 'VC71' TabStyle."""))
+
+        ShowDropdownTabList = property(_getShowDropdownTabList, _setShowDropdownTabList, None,
+                _("""Specifies whether the dropdown tab list button is visible in the menu (bool) (Default=False)
+                Setting this property to True will set ShowNavButtons to False"""))
+
+        ShowMenuCloseButton = property(_getShowMenuCloseButton, _setShowMenuCloseButton, None,
+                _("Specifies whether the close button is visible in the menu (bool) (Default=True)"))
+
+        ShowMenuOnSingleTab = property(_getShowMenuOnSingleTab, _setShowMenuOnSingleTab, None,
+                _("Specifies whether the tab thumbs and nav buttons are shown when there is a single tab. (bool) (Default=True)"))
+
+        ShowNavButtons = property(_getShowNavButtons, _setShowNavButtons, None,
+                _("""Specifies whether the left and right nav buttons are visible in the menu (bool) (Default=True)
+                Setting this property to True will set ShowDropdownTabList to False"""))
+
+        ShowPageCloseButtons = property(_getShowPageCloseButtons, _setShowPageCloseButtons, None,
+                _("Specifies whether the close button is visible on the page tab (bool) (Default=False)"))
+
+        TabAreaColor = property(_getTabAreaColor, _setTabAreaColor, None,
+                _("""Specifies the background color of the tab area. This is exactly the same as
+                the 'MenuBackColor' property, but with a more intuitive name.  (str or 3-tuple)
+                (Default=None) Note: is not visible with 'VC71' TabStyle."""))
+
+        TabPosition = property(_getTabPosition, _setTabPosition, None,
+                _("""Specifies where the page tabs are located. (string)
+                    Top (default)
+                    Bottom
+                    """) )
+
+        TabSideIncline = property(_getTabSideIncline, _setTabSideIncline, None,
+                _("""Specifies the incline of the sides of the tab in degrees (int) (Default=0)
+                    Acceptable values are 0  - 15.
+                    Note: this property will have no effect on TabStyles other than Default.
+                    """))
+
+        TabStyle = property(_getTabStyle, _setTabStyle, None,
+                _("""Specifies the style of the display tabs. (string)
+                    "Default" (default)
+                    "VC8"
+                    "VC71"
+                    "Fancy"
+                    "Firefox"
+                    """))
 
 
 import random
@@ -702,62 +700,63 @@ class _dPageFrame_test(TestMixin, dPageFrame): pass
 class _dPageList_test(TestMixin, dPageList): pass
 class _dPageSelect_test(TestMixin, dPageSelect): pass
 class _dDockTabs_test(TestMixin, dDockTabs): pass
-class _dPageStyled_test(TestMixin, dPageStyled):
-    def initProperties(self):
-        self.Width = 500
-        self.Height = 250
-        self.PageCount = 4
-        self.TabStyle = random.choice(("Default", "VC8", "VC71", "Fancy", "Firefox"))
-        self.TabPosition = random.choice(("Top", "Bottom"))
-        self.ShowPageCloseButtons = random.choice((True, False))
-        self.ShowDropdownTabList = random.choice((True, False))
-        self.ShowMenuClose = random.choice((True, False))
-        self.ShowMenuOnSingleTab = random.choice((True, False))
-        self.ShowNavButtons = random.choice((True, False))
-        self.MenuBackColor = "lightsteelblue"
-        self.InactiveTabTextColor = "darkcyan"
-        self.ActiveTabTextColor = "blue"
+if _USE_FLAT:
+    class _dPageStyled_test(TestMixin, dPageStyled):
+        def initProperties(self):
+            self.Width = 500
+            self.Height = 250
+            self.PageCount = 4
+            self.TabStyle = random.choice(("Default", "VC8", "VC71", "Fancy", "Firefox"))
+            self.TabPosition = random.choice(("Top", "Bottom"))
+            self.ShowPageCloseButtons = random.choice((True, False))
+            self.ShowDropdownTabList = random.choice((True, False))
+            self.ShowMenuClose = random.choice((True, False))
+            self.ShowMenuOnSingleTab = random.choice((True, False))
+            self.ShowNavButtons = random.choice((True, False))
+            self.MenuBackColor = "lightsteelblue"
+            self.InactiveTabTextColor = "darkcyan"
+            self.ActiveTabTextColor = "blue"
 
-    def afterInit(self):
-        # Make the pages visible by setting a BackColor
-        self.Pages[0].BackColor = "darkred"
-        self.Pages[1].BackColor = "darkblue"
-        self.Pages[2].BackColor = "green"
-        self.Pages[3].BackColor = "yellow"
-        # Can't add controls to the Test form now, so use callAfter() to delay
-        # the actual control creation.
-        dui.callAfter(self._addControls)
+        def afterInit(self):
+            # Make the pages visible by setting a BackColor
+            self.Pages[0].BackColor = "darkred"
+            self.Pages[1].BackColor = "darkblue"
+            self.Pages[2].BackColor = "green"
+            self.Pages[3].BackColor = "yellow"
+            # Can't add controls to the Test form now, so use callAfter() to delay
+            # the actual control creation.
+            dui.callAfter(self._addControls)
 
-    def _addControls(self):
-        pnl = self.Form.Children[0]
-        szr = pnl.Sizer
-        szr.DefaultBorder = 2
-        chk = dui.dCheckBox(pnl, Caption="Show Page Close Buttons",
-                DataSource=self, DataField="ShowPageCloseButtons")
-        szr.append(chk, halign="center")
-        chk = dui.dCheckBox(pnl, Caption="Show Nav Buttons",
-                DataSource=self, DataField="ShowNavButtons")
-        szr.append(chk, halign="center")
-        chk = dui.dCheckBox(pnl, Caption="Show Menu Close",
-                DataSource=self, DataField="ShowMenuClose")
-        szr.append(chk, halign="center")
-        lbl = dui.dLabel(pnl, Caption="Tab Style:")
-        dd = dui.dDropdownList(pnl,
-                Choices=["Default", "VC8", "VC71", "Fancy", "Firefox"],
-                DataSource=self, DataField="TabStyle")
-        hsz = dui.dSizer("h")
-        hsz.append(lbl)
-        hsz.append(dd)
-        szr.append(hsz, halign="center")
-        lbl = dui.dLabel(pnl, Caption="Tab Position:")
-        dd = dui.dDropdownList(pnl, Choices=["Top", "Bottom"],
-                DataSource=self, DataField="TabPosition")
-        hsz = dui.dSizer("h")
-        hsz.append(lbl)
-        hsz.append(dd)
-        szr.append(hsz, halign="center")
-        self.Form.layout()
-        self.Form.fitToSizer()
+        def _addControls(self):
+            pnl = self.Form.Children[0]
+            szr = pnl.Sizer
+            szr.DefaultBorder = 2
+            chk = dui.dCheckBox(pnl, Caption="Show Page Close Buttons",
+                    DataSource=self, DataField="ShowPageCloseButtons")
+            szr.append(chk, halign="center")
+            chk = dui.dCheckBox(pnl, Caption="Show Nav Buttons",
+                    DataSource=self, DataField="ShowNavButtons")
+            szr.append(chk, halign="center")
+            chk = dui.dCheckBox(pnl, Caption="Show Menu Close",
+                    DataSource=self, DataField="ShowMenuClose")
+            szr.append(chk, halign="center")
+            lbl = dui.dLabel(pnl, Caption="Tab Style:")
+            dd = dui.dDropdownList(pnl,
+                    Choices=["Default", "VC8", "VC71", "Fancy", "Firefox"],
+                    DataSource=self, DataField="TabStyle")
+            hsz = dui.dSizer("h")
+            hsz.append(lbl)
+            hsz.append(dd)
+            szr.append(hsz, halign="center")
+            lbl = dui.dLabel(pnl, Caption="Tab Position:")
+            dd = dui.dDropdownList(pnl, Choices=["Top", "Bottom"],
+                    DataSource=self, DataField="TabPosition")
+            hsz = dui.dSizer("h")
+            hsz.append(lbl)
+            hsz.append(dd)
+            szr.append(hsz, halign="center")
+            self.Form.layout()
+            self.Form.fitToSizer()
 
     def onPageChanged(self, evt):
         print("Page number changed from %s to %s" % (evt.oldPageNum, evt.newPageNum))
@@ -771,4 +770,5 @@ if __name__ == "__main__":
     test.Test().runTest(_dPageList_test)
     test.Test().runTest(_dPageSelect_test)
     test.Test().runTest(_dDockTabs_test)
-    test.Test().runTest(_dPageStyled_test)
+    if _USE_FLAT:
+        test.Test().runTest(_dPageStyled_test)

--- a/dabo/ui/dPageFrame.py
+++ b/dabo/ui/dPageFrame.py
@@ -52,9 +52,9 @@ class dPageFrame(dPageFrameMixin, wx.Notebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageFrame
-        wxClass = wx.Notebook
+        preClass = wx.PreNotebook
 
-        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def _afterInit(self):
@@ -74,9 +74,9 @@ class dPageToolBar(dPageFrameMixin, wx.Toolbook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageToolBar
-        wxClass = wx.Toolbook
+        preClass = wx.PreToolbook
 
-        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def _afterInit(self):
@@ -130,10 +130,10 @@ class dPageList(dPageFrameMixin, wx.Listbook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageList
-        wxClass = wx.Listbook
+        preClass = wx.PreListbook
         # Dictionary for tracking images by key value
         self._imageList = {}
-        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
         self.Bind(wx.EVT_LIST_ITEM_MIDDLE_CLICK, self.__onWxMiddleClick)
@@ -191,8 +191,8 @@ class dPageSelect(dPageFrameMixin, wx.Choicebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPageSelect
-        wxClass = wx.Choicebook
-        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreChoicebook
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         # Dictionary for tracking images by key value
         self._imageList = {}
@@ -225,7 +225,7 @@ class dDockTabs(dPageFrameMixin, aui.AuiNotebook):
 
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dDockTabs
-        wxClass = aui.AuiNotebook
+        preClass = aui.AuiNotebook
 
         newStyle = (aui.AUI_NB_TOP | aui.AUI_NB_SCROLL_BUTTONS)
         self._movableTabs = self._extractKey((properties, attProperties, kwargs), "MovableTabs", True)
@@ -238,7 +238,7 @@ class dDockTabs(dPageFrameMixin, aui.AuiNotebook):
             kwargs["agwStyle"] = newStyle
         else:
             kwargs["style"] = newStyle
-        dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
+        dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -308,13 +308,13 @@ if _USE_FLAT:
 
         def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
             self._baseClass = dPageStyled
-            wxClass = fnb.FlatNotebook
+            preClass = fnb.FlatNotebook
             # For some reason this class always opens to the *last* page, unlike all other
             # paged controls. This will make it open to the first page, unless otherwise
             # explicitly set.
             selpg = int(self._extractKey((properties, attProperties, kwargs), "SelectedPageNumber",
                     defaultVal=0))
-            dPageFrameMixin.__init__(self, wxClass, parent, properties=properties,
+            dPageFrameMixin.__init__(self, preClass, parent, properties=properties,
                     attProperties=attProperties, *args, **kwargs)
             dui.setAfter(self, "SelectedPageNumber", selpg)
 

--- a/dabo/ui/dPageFrameMixin.py
+++ b/dabo/ui/dPageFrameMixin.py
@@ -17,17 +17,16 @@ MSG_SMART_FOCUS_ABUSE = _("The '%s' control must inherit from dPage to use the U
 class dPageFrameMixin(dControlMixin):
     """Creates a container for an unlimited number of pages."""
 
-    def __init__(self, wxClass, parent, properties=None, attProperties=None, *args, **kwargs):
+    def __init__(self, preClass, parent, properties=None, attProperties=None, *args, **kwargs):
         kwargs["style"] = self._extractKey((properties, kwargs), "style", 0) | wx.CLIP_CHILDREN
-        super(dPageFrameMixin, self).__init__(wxClass, parent, properties=properties,
+        super(dPageFrameMixin, self).__init__(preClass, parent, properties=properties,
             attProperties=attProperties, *args, **kwargs)
 
 
-    def _beforeInit(self):
-        from dabo.ui.dSizer import dSizer
+    def _beforeInit(self, pre):
         self._imageList = {}
-        self._pageSizerClass = dSizer
-        super(dPageFrameMixin, self)._beforeInit()
+        self._pageSizerClass = dui.dSizer
+        super(dPageFrameMixin, self)._beforeInit(pre)
 
 
     def _initEvents(self):

--- a/dabo/ui/dPageFrameMixin.py
+++ b/dabo/ui/dPageFrameMixin.py
@@ -17,9 +17,9 @@ MSG_SMART_FOCUS_ABUSE = _("The '%s' control must inherit from dPage to use the U
 class dPageFrameMixin(dControlMixin):
     """Creates a container for an unlimited number of pages."""
 
-    def __init__(self, preClass, parent, properties=None, attProperties=None, *args, **kwargs):
+    def __init__(self, wxClass, parent, properties=None, attProperties=None, *args, **kwargs):
         kwargs["style"] = self._extractKey((properties, kwargs), "style", 0) | wx.CLIP_CHILDREN
-        super(dPageFrameMixin, self).__init__(preClass, parent, properties=properties,
+        super(dPageFrameMixin, self).__init__(wxClass, parent, properties=properties,
             attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dPanel.py
+++ b/dabo/ui/dPanel.py
@@ -11,7 +11,7 @@ from dabo.ui.dDataControlMixin import dDataControlMixin
 
 
 class _BasePanelMixin(object):
-    def __init__(self, superclass, wxClass, parent, properties=None, attProperties=None,
+    def __init__(self, superclass, preClass, parent, properties=None, attProperties=None,
             *args, **kwargs):
         self._minSizerWidth = 10
         self._minSizerHeight = 10
@@ -29,7 +29,7 @@ class _BasePanelMixin(object):
         kwargs["style"] = style
         # For performance, store this at init
         self._platformIsWindows = (self.Application.Platform == "Win")
-        superclass.__init__(self, wxClass=wxClass, parent=parent,
+        superclass.__init__(self, preClass=preClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
         self._inResizeHandler = False
@@ -237,16 +237,16 @@ class _BasePanelMixin(object):
 
 
 class _PanelMixin(dControlMixin, _BasePanelMixin):
-    def __init__(self, wxClass, parent, properties=None, attProperties=None,
+    def __init__(self, preClass, parent, properties=None, attProperties=None,
             *args, **kwargs):
-        _BasePanelMixin.__init__(self, dControlMixin, wxClass=wxClass, parent=parent,
+        _BasePanelMixin.__init__(self, dControlMixin, preClass=preClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
 
 class _DataPanelMixin(dDataControlMixin, _BasePanelMixin):
-    def __init__(self, wxClass, parent, properties=None, attProperties=None,
+    def __init__(self, preClass, parent, properties=None, attProperties=None,
             *args, **kwargs):
-        _BasePanelMixin.__init__(self, dDataControlMixin, wxClass=wxClass, parent=parent,
+        _BasePanelMixin.__init__(self, dDataControlMixin, preClass=preClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
 
@@ -260,8 +260,8 @@ class dPanel(_PanelMixin, wx.Panel):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPanel
-        wxClass = wx.Panel
-        _PanelMixin.__init__(self, wxClass=wxClass, parent=parent, properties=properties,
+        preClass = wx.PrePanel
+        _PanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -279,8 +279,8 @@ class dDataPanel(_DataPanelMixin, wx.Panel):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dDataPanel
-        wxClass = wx.Panel
-        _DataPanelMixin.__init__(self, wxClass=wxClass, parent=parent, properties=properties,
+        preClass = wx.PrePanel
+        _DataPanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -293,16 +293,13 @@ class dScrollPanel(_PanelMixin, wx.ScrolledWindow):
     flexible for many uses. Consider laying out your forms on panels
     instead, and then adding the panel to the form.
     """
-    def __init__(self, parent, properties=None, attProperties=None, *args,
-        **kwargs):
+    def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._horizontalScroll = self._verticalScroll = True
         self._baseClass = dScrollPanel
-        wxClass = wx.ScrolledWindow
-        kwargs["AlwaysResetSizer"] = self._extractKey((properties, kwargs,
-                attProperties), "AlwaysResetSizer", True)
-        _PanelMixin.__init__(self, wxClass=wxClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        preClass = wx.PreScrolledWindow
+        kwargs["AlwaysResetSizer"] = self._extractKey((properties, kwargs, attProperties), "AlwaysResetSizer", True)
+        _PanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
         self.SetScrollRate(10, 10)
         self.Bind(wx.EVT_SCROLLWIN, self.__onWxScrollWin)
 
@@ -355,10 +352,9 @@ class dScrollPanel(_PanelMixin, wx.ScrolledWindow):
 
 
     def _getChildren(self):
-        from dabo.ui.dPemMixin import dPemMixin
         ret = super(dScrollPanel, self)._getChildren()
         return [kid for kid in ret
-                if isinstance(kid, dPemMixin)]
+                if isinstance(kid, dabo.ui.dPemMixinBase.dPemMixinBase)]
 
     def _setChildren(self, val):
         super(dScrollPanel, self)._setChildren(val)

--- a/dabo/ui/dPanel.py
+++ b/dabo/ui/dPanel.py
@@ -29,7 +29,7 @@ class _BasePanelMixin(object):
         kwargs["style"] = style
         # For performance, store this at init
         self._platformIsWindows = (self.Application.Platform == "Win")
-        super(_BasePanelMixin, self).__init__(preClass=preClass, parent=parent,
+        superclass.__init__(self, preClass=preClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
         self._inResizeHandler = False
@@ -235,7 +235,22 @@ class _BasePanelMixin(object):
             Default=False  (bool)"""))
 
 
-class dPanel(dControlMixin, _BasePanelMixin, wx.Panel):
+
+class _PanelMixin(dControlMixin, _BasePanelMixin):
+    def __init__(self, preClass, parent, properties=None, attProperties=None,
+            *args, **kwargs):
+        _BasePanelMixin.__init__(self, dControlMixin, preClass=preClass, parent=parent,
+                properties=properties, attProperties=attProperties, *args, **kwargs)
+
+
+class _DataPanelMixin(dDataControlMixin, _BasePanelMixin):
+    def __init__(self, preClass, parent, properties=None, attProperties=None,
+            *args, **kwargs):
+        _BasePanelMixin.__init__(self, dDataControlMixin, preClass=preClass, parent=parent,
+                properties=properties, attProperties=attProperties, *args, **kwargs)
+
+
+class dPanel(_PanelMixin, wx.Panel):
     """
     Creates a panel, a basic container for controls.
 
@@ -246,12 +261,11 @@ class dPanel(dControlMixin, _BasePanelMixin, wx.Panel):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPanel
         preClass = wx.Panel
-        super(dPanel, self).__init__(preClass=preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        _PanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
-class dDataPanel(dDataControlMixin, _BasePanelMixin, wx.Panel):
+class dDataPanel(_DataPanelMixin, wx.Panel):
     """
     Creates a panel, a basic container for controls. This panel, unlike the plain
     dPanel class, inherits from the Data Control mixin class, which makes it useful
@@ -266,13 +280,12 @@ class dDataPanel(dDataControlMixin, _BasePanelMixin, wx.Panel):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dDataPanel
         preClass = wx.Panel
-        super(dDataPanel, self).__init__(preClass=preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        _DataPanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
 
-class dScrollPanel(dControlMixin, _BasePanelMixin, wx.ScrolledWindow):
+class dScrollPanel(_PanelMixin, wx.ScrolledWindow):
     """
     This is a basic container for controls that allows scrolling.
 
@@ -287,7 +300,7 @@ class dScrollPanel(dControlMixin, _BasePanelMixin, wx.ScrolledWindow):
         preClass = wx.ScrolledWindow
         kwargs["AlwaysResetSizer"] = self._extractKey((properties, kwargs,
                 attProperties), "AlwaysResetSizer", True)
-        super(dScrollPanel, self).__init__(preClass=preClass, parent=parent,
+        _PanelMixin.__init__(self, preClass=preClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args,
                 **kwargs)
         self.SetScrollRate(10, 10)

--- a/dabo/ui/dPanel.py
+++ b/dabo/ui/dPanel.py
@@ -11,7 +11,7 @@ from dabo.ui.dDataControlMixin import dDataControlMixin
 
 
 class _BasePanelMixin(object):
-    def __init__(self, superclass, preClass, parent, properties=None, attProperties=None,
+    def __init__(self, superclass, wxClass, parent, properties=None, attProperties=None,
             *args, **kwargs):
         self._minSizerWidth = 10
         self._minSizerHeight = 10
@@ -29,7 +29,7 @@ class _BasePanelMixin(object):
         kwargs["style"] = style
         # For performance, store this at init
         self._platformIsWindows = (self.Application.Platform == "Win")
-        superclass.__init__(self, preClass=preClass, parent=parent,
+        superclass.__init__(self, wxClass=wxClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
         self._inResizeHandler = False
@@ -237,16 +237,16 @@ class _BasePanelMixin(object):
 
 
 class _PanelMixin(dControlMixin, _BasePanelMixin):
-    def __init__(self, preClass, parent, properties=None, attProperties=None,
+    def __init__(self, wxClass, parent, properties=None, attProperties=None,
             *args, **kwargs):
-        _BasePanelMixin.__init__(self, dControlMixin, preClass=preClass, parent=parent,
+        _BasePanelMixin.__init__(self, dControlMixin, wxClass=wxClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
 
 class _DataPanelMixin(dDataControlMixin, _BasePanelMixin):
-    def __init__(self, preClass, parent, properties=None, attProperties=None,
+    def __init__(self, wxClass, parent, properties=None, attProperties=None,
             *args, **kwargs):
-        _BasePanelMixin.__init__(self, dDataControlMixin, preClass=preClass, parent=parent,
+        _BasePanelMixin.__init__(self, dDataControlMixin, wxClass=wxClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args, **kwargs)
 
 
@@ -260,8 +260,8 @@ class dPanel(_PanelMixin, wx.Panel):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPanel
-        preClass = wx.Panel
-        _PanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
+        wxClass = wx.Panel
+        _PanelMixin.__init__(self, wxClass=wxClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -279,8 +279,8 @@ class dDataPanel(_DataPanelMixin, wx.Panel):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dDataPanel
-        preClass = wx.Panel
-        _DataPanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
+        wxClass = wx.Panel
+        _DataPanelMixin.__init__(self, wxClass=wxClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -297,10 +297,10 @@ class dScrollPanel(_PanelMixin, wx.ScrolledWindow):
         **kwargs):
         self._horizontalScroll = self._verticalScroll = True
         self._baseClass = dScrollPanel
-        preClass = wx.ScrolledWindow
+        wxClass = wx.ScrolledWindow
         kwargs["AlwaysResetSizer"] = self._extractKey((properties, kwargs,
                 attProperties), "AlwaysResetSizer", True)
-        _PanelMixin.__init__(self, preClass=preClass, parent=parent,
+        _PanelMixin.__init__(self, wxClass=wxClass, parent=parent,
                 properties=properties, attProperties=attProperties, *args,
                 **kwargs)
         self.SetScrollRate(10, 10)

--- a/dabo/ui/dPanel.py
+++ b/dabo/ui/dPanel.py
@@ -260,7 +260,7 @@ class dPanel(_PanelMixin, wx.Panel):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dPanel
-        preClass = wx.PrePanel
+        preClass = wx.Panel
         _PanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
@@ -279,7 +279,7 @@ class dDataPanel(_DataPanelMixin, wx.Panel):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dDataPanel
-        preClass = wx.PrePanel
+        preClass = wx.Panel
         _DataPanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
@@ -296,7 +296,7 @@ class dScrollPanel(_PanelMixin, wx.ScrolledWindow):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._horizontalScroll = self._verticalScroll = True
         self._baseClass = dScrollPanel
-        preClass = wx.PreScrolledWindow
+        preClass = wx.ScrolledWindow
         kwargs["AlwaysResetSizer"] = self._extractKey((properties, kwargs, attProperties), "AlwaysResetSizer", True)
         _PanelMixin.__init__(self, preClass=preClass, parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)

--- a/dabo/ui/dPdfWindow.py
+++ b/dabo/ui/dPdfWindow.py
@@ -35,9 +35,8 @@ class dPdfWindow(dControlMixin, PDFWindow):
 
         self._baseClass = dPdfWindow
         preClass = pdfwin.PDFWindow
-        super(dPdfWindow, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
 

--- a/dabo/ui/dPemMixin.py
+++ b/dabo/ui/dPemMixin.py
@@ -56,7 +56,7 @@ class dPemMixin(dObject):
         # Dictionary to keep track of Dynamic properties
         self._dynamic = {}
         if threeWayInit:
-            # Instantiate the wx Pre object
+            # Instantiate the wx. object
             pre = preClass()
         else:
             pre = None
@@ -154,12 +154,16 @@ class dPemMixin(dObject):
             del(self._preInitProperties["style"])
             del(self._preInitProperties["id"])
             del(self._preInitProperties["parent"])
+
+            # TODO: fix thix block
+            """
         elif isinstance(self, (dui.dSlidePanel, dui.dSlidePanelControl,
                 dSlidePanelControl.dSlidePanel, dSlidePanelControl.dSlidePanelControl)):
             # Hack: the Slide Panel classes have no style arg.
             del self._preInitProperties["style"]
             # This is needed because these classes require a 'parent' param.
             kwargs["parent"] = parent
+            """
         elif wx.VERSION >= (2, 8, 8) and isinstance(self, (wx.lib.platebtn.PlateButton)):
             self._preInitProperties["id_"] = self._preInitProperties["id"]
             del self._preInitProperties["id"]
@@ -200,7 +204,7 @@ class dPemMixin(dObject):
         self._initEvents()
         self._afterInit()
 
-        dPemMixinBase.__init__(self)  ## don't use super(), or wx init called 2x.
+        dObject.__init__(self)
 
         if dabo.fastNameSet:
             # Event AutoBinding is set to happen when the Name property changes, but
@@ -537,7 +541,8 @@ class dPemMixin(dObject):
         self.Bind(wx.EVT_IDLE, self.__onWxIdle)
         self.Bind(wx.EVT_MENU_OPEN, targ.__onWxMenuOpen)
 
-        if isinstance(self, dui.dGrid):
+        from dabo.ui.dGrid import dGrid
+        if isinstance(self, dGrid):
             ## Ugly workaround for grids not firing focus events from the keyboard
             ## correctly.
             self._lastGridFocusTimestamp = 0.0
@@ -705,7 +710,8 @@ class dPemMixin(dObject):
 
     def __onWxMenuOpen(self, evt):
         menu = evt.GetMenu()
-        if menu and isinstance(menu, dui.dMenu):
+        from dabo.ui.dMenu import dMenu
+        if menu and isinstance(menu, dMenu):
             menu.raiseEvent(dEvents.MenuOpen, evt)
         evt.Skip()
 
@@ -717,7 +723,8 @@ class dPemMixin(dObject):
             # 'Form' is None
             pass
         self._pushStatusText()
-        if isinstance(self, dui.dGrid):
+        from dabo.ui.dGrid import dGrid
+        if isinstance(self, dGrid):
             ## Continuation of ugly workaround for grid focus event. Only raise the
             ## Dabo event if we are reasonably sure it isn't a repeat.
             prev = self._lastGridFocusTimestamp
@@ -865,7 +872,8 @@ class dPemMixin(dObject):
         if self._finito:
             return
         self._needRedraw = bool(self._drawnObjects)
-        if sys.platform.startswith("win") and isinstance(self, dui.dFormMixin):
+        from dabo.ui.dFormMixin import dFormMixin
+        if sys.platform.startswith("win") and isinstance(self, dFormMixin):
             dui.callAfterInterval(200, self.update)
         self.raiseEvent(dEvents.Resize, evt)
 
@@ -1485,7 +1493,7 @@ class dPemMixin(dObject):
 
     def __onUpdate(self, evt):
         """Update any dynamic properties, and then call the update() hook."""
-        if isinstance(self, dui.deadObject) or not self._constructed():
+        if not (self) or not self._constructed():
             return
         # Check paged controls event propagation to inactive pages.
         try:
@@ -1502,7 +1510,7 @@ class dPemMixin(dObject):
             if not updateInactive and not self.Visible:
                 # (some platforms have inactive pages not visible)
                 return
-        if isinstance(self, dui.dFormMixin) and not self.Visible:
+        if isinstance(self, dui.dFormMixin.dFormMixin) and not self.Visible:
             return
         self.update()
 
@@ -1516,11 +1524,12 @@ class dPemMixin(dObject):
 
     def update(self):
         """Update the properties of this object and all contained objects."""
-        if isinstance(self, dui.deadObject):
+        from dabo.ui.dForm import dForm
+        if not self:
             # This can happen if an object is released when there is a
             # pending callAfter() refresh.
             return
-        if isinstance(self, dui.dForm) and self.AutoUpdateStatusText \
+        if isinstance(self, dForm) and self.AutoUpdateStatusText \
                 and self.Visible:
             self.setStatusText(self.getCurrentRecordText(), immediate=True)
         if self.Children:
@@ -1551,7 +1560,7 @@ class dPemMixin(dObject):
         """Repaints this control and all contained objects."""
         try:
             self.Refresh()
-        except dui.deadObjectException:
+        except RuntimeError:
             # This can happen if an object is released when there is a
             # pending callAfter() refresh.
             pass
@@ -2222,7 +2231,9 @@ class dPemMixin(dObject):
             """Windows textboxes change their value when SetLabel() is called; this
             avoids that problem.
             """
-            if not isinstance(self, (dui.dTextBox, dui.dEditBox)):
+            from dabo.ui.dEditBox import dEditBox
+            from dabo.ui.dTextBox import dTextBox
+            if not isinstance(self, (dTextBox, dEditBox)):
                 self._caption = val
                 uval = ustr(val)
                 ## 2/23/2005: there is a bug in wxGTK that resets the font when the
@@ -2355,12 +2366,12 @@ class dPemMixin(dObject):
         if hasattr(self, "_font") and isinstance(self._font, dui.dFont):
             v = self._font
         else:
-            v = self.Font = dui.dFont(_nativeFont=self.GetFont())
+            v = self.Font = dui.dFont.dFont(_nativeFont=self.GetFont())
         return v
 
     def _setDaboFont(self, val):
         #PVG: also accep wxFont parameter
-        if isinstance(val, (wx.Font, wx._gdi.Font)):
+        if isinstance(val, (wx.Font, wx.Font)):
             val = dui.dFont(_nativeFont=val)
         if self._constructed():
             self._font = val
@@ -2453,13 +2464,14 @@ class dPemMixin(dObject):
             return self._cachedForm
         except AttributeError:
             import dabo.ui
+            from dabo.ui.dFormMixin import dFormMixin
             obj, frm = self, None
             while obj:
                 try:
                     parent = obj.Parent
                 except AttributeError:
                     break
-                if isinstance(parent, (dabo.ui.dFormMixin)):
+                if isinstance(parent, dFormMixin):
                     frm = parent
                     break
                 else:
@@ -2509,7 +2521,9 @@ class dPemMixin(dObject):
     def _setLeft(self, val):
         if self._constructed():
             self.SetPosition((int(val), self.Top))
-        if isinstance(self, dui.dFormMixin):
+
+        from dabo.ui.dFormMixin import dFormMixin
+        if isinstance(self, dFormMixin):
             self._defaultLeft = val
         else:
             self._properties["Left"] = val
@@ -2765,7 +2779,9 @@ class dPemMixin(dObject):
     def _setPosition(self, val):
         if self._constructed():
             left, top = val
-            if isinstance(self, dui.dFormMixin):
+
+            from dabo.ui.dFormMixin import dFormMixin
+            if isinstance(self, dFormMixin):
                 self._defaultLeft, self._defaultTop = (left, top)
             self.SetPosition((left, top))
         else:
@@ -2822,7 +2838,9 @@ class dPemMixin(dObject):
                 else:
                     # prior to wxPython 2.7.s:
                     self.SetBestFittingSize(val)
-            if isinstance(self, dui.dFormMixin):
+
+            from dabo.ui.dFormMixin import dFormMixin
+            if isinstance(self, dFormMixin):
                 self._defaultWidth, self._defaultHeight = val
         else:
             self._properties["Size"] = val
@@ -2903,7 +2921,8 @@ class dPemMixin(dObject):
 
     def _setTop(self, val):
         if self._constructed():
-            if isinstance(self, dui.dFormMixin):
+            from dabo.ui.dFormMixin import dFormMixin
+            if isinstance(self, dFormMixin):
                 self._defaultTop = val
             self.SetPosition((self.Left, int(val)))
         else:

--- a/dabo/ui/dPemMixin.py
+++ b/dabo/ui/dPemMixin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import sys
 import time
 import types
@@ -28,9 +27,8 @@ class dPemMixin(dObject):
     _call_beforeInit, _call_afterInit, _call_initProperties = False, False, False
     _layout_on_set_caption = False
 
-    def __init__(self, wxClass=None, parent=None, properties=None,
-            attProperties=None, _explicitName=None, srcCode=None, *args,
-            **kwargs):
+    def __init__(self, preClass=None, parent=None, properties=None,
+            attProperties=None, srcCode=None, *args, **kwargs):
         # This is the major, common constructor code for all the dabo/ui/uiwx
         # classes. The __init__'s of each class are just thin wrappers to this
         # code.
@@ -48,21 +46,38 @@ class dPemMixin(dObject):
         # DataControl enabling/disabling helper attribute.
         self._uiDisabled = False
 
+        # There are a few controls that don't yet support 3-way inits (grid, for
+        # one). These controls will send the wx classref as the preClass argument,
+        # and we'll call __init__ on it when ready. We can tell if we are in a
+        # three-way init situation based on whether or not preClass is a function
+        # type.
+        threeWayInit = (type(preClass) == types.FunctionType)
+
         # Dictionary to keep track of Dynamic properties
         self._dynamic = {}
+        if threeWayInit:
+            # Instantiate the wx Pre object
+            pre = preClass()
+        else:
+            pre = None
 
         if srcCode:
             self._addCodeAsMethod(srcCode)
 
-        self._beforeInit()
+        self._beforeInit(pre)
         # If the _EventTarget property is passed, extract it before any of the other
         # property-processing code runs.
         self._eventTarget = self._extractKey((properties, attProperties, kwargs), "_EventTarget",
                 defaultVal=self)
-    
-        # Some kwargs are not passed as Dabo properties, but wx-specific
-        # values. We need to separate these so that the code for processing
-        # properties doesn't choke on them.
+        # Lots of useful wx props are actually only settable before the
+        # object is fully constructed. The self._preInitProperties dict keeps
+        # track of those during the pre-init phase, to finally send the
+        # contents of it to the wx constructor. Our property setters know
+        # if we are in pre-init or not, and instead of trying to modify
+        # the prop will instead add the appropriate entry to the _preInitProperties
+        # dict. Additionally, there are certain wx properties that are required,
+        # and we include those in the _preInitProperties dict as well so they may
+        # be modified by our pre-init method hooks if needed:
         self._preInitProperties = {"parent": parent}
         for arg, default in (("style", 0), ("id", -1)):
             try:
@@ -72,6 +87,10 @@ class dPemMixin(dObject):
                 self._preInitProperties[arg] = default
 
         self._initProperties()
+
+        # Now that user code has had an opportunity to set the properties, we can
+        # see if there are properties sent to the constructor which will augment
+        # or override the properties as currently set.
 
         # The keyword properties can come from either, both, or none of:
         #    + the properties dict
@@ -112,6 +131,38 @@ class dPemMixin(dObject):
                 properties[prop] = attVal
         properties = dictStringify(properties)
 
+        # Hacks to fix up various things:
+        from . import dMenuBar, dMenuItem, dMenu, dSlidePanelControl, dToggleButton
+        if wx.VERSION >= (2, 8, 8):
+            from . import dBorderlessButton
+        if isinstance(self, (dMenuItem.dMenuItem, dMenuItem.dSeparatorMenuItem)):
+            # Hack: wx.MenuItem doesn't take a style arg,
+            # and the parent arg is parentMenu.
+            del self._preInitProperties["style"]
+            self._preInitProperties["parentMenu"] = parent
+            del self._preInitProperties["parent"]
+            if isinstance(self, dMenuItem.dSeparatorMenuItem):
+                del(self._preInitProperties["id"])
+                for remove in ("HelpText", "Icon", "kind"):
+                    self._extractKey((properties, self._properties, kwargs), remove)
+        elif isinstance(self, (dMenu.dMenu, dMenuBar.dMenuBar)):
+            # Hack: wx.Menu has no style, parent, or id arg.
+            del(self._preInitProperties["style"])
+            del(self._preInitProperties["id"])
+            del(self._preInitProperties["parent"])
+        elif isinstance(self, wx.Timer):
+            del(self._preInitProperties["style"])
+            del(self._preInitProperties["id"])
+            del(self._preInitProperties["parent"])
+        elif isinstance(self, (dui.dSlidePanel, dui.dSlidePanelControl,
+                dSlidePanelControl.dSlidePanel, dSlidePanelControl.dSlidePanelControl)):
+            # Hack: the Slide Panel classes have no style arg.
+            del self._preInitProperties["style"]
+            # This is needed because these classes require a 'parent' param.
+            kwargs["parent"] = parent
+        elif wx.VERSION >= (2, 8, 8) and isinstance(self, (wx.lib.platebtn.PlateButton)):
+            self._preInitProperties["id_"] = self._preInitProperties["id"]
+            del self._preInitProperties["id"]
         # This is needed when running from a saved design file
         self._extractKey((properties, self._properties), "designerClass")
         # This attribute is used when saving code with a design file
@@ -122,26 +173,34 @@ class dPemMixin(dObject):
         # The user's subclass code has had a chance to tweak the init properties.
         # Insert any of those into the arguments to send to the wx constructor:
         properties = self._setInitProperties(**properties)
+        for prop in list(self._preInitProperties.keys()):
+            kwargs[prop] = self._preInitProperties[prop]
         # Allow the object a chance to add any required parms, such as OptionGroup
         # which needs a choices parm in order to instantiate.
         kwargs = self._preInitUI(kwargs)
-        if wxClass:
-            wxProps, kwargs = self._fixWxProps(properties,
-                    self._preInitProperties, **kwargs)
-            wxClass.__init__(self, **wxProps)
 
-        super(dPemMixin, self).__init__(*args, **kwargs)
+        # Do the init:
+        if threeWayInit:
+            pre.Create(*args, **kwargs)
+        elif preClass is None:
+            pass
+        else:
+            preClass.__init__(self, *args, **kwargs)
+
+        if threeWayInit:
+            self.PostCreate(pre)
+
         self._pemObject = self
 
         if self._constructed():
             # (some objects could have overridden _constructed() and don't want
             # us to call _setNameAndProperties() here..)
-            all_kwargs = copy.deepcopy(kwargs)
-            all_kwargs["_explicitName"] = _explicitName
-            self._setNameAndProperties(properties, **all_kwargs)
+            self._setNameAndProperties(properties, **kwargs)
 
         self._initEvents()
         self._afterInit()
+
+        dPemMixinBase.__init__(self)  ## don't use super(), or wx init called 2x.
 
         if dabo.fastNameSet:
             # Event AutoBinding is set to happen when the Name property changes, but
@@ -160,55 +219,42 @@ class dPemMixin(dObject):
         self.raiseEvent(dEvents.Create)
 
 
-    def _fixWxProps(self, properties, preProps, **kwargs):
-        # Hacks to fix up various things:
-        from dabo.ui.dBorderlessButton import dBorderlessButton
-        from dabo.ui.dMenu import dMenu
-        from dabo.ui.dMenuBar import dMenuBar
-        from dabo.ui.dMenuItem import dMenuItem
-        from dabo.ui.dMenuItem import dSeparatorMenuItem
-        from dabo.ui.dSlidePanelControl import dSlidePanel
-        from dabo.ui.dSlidePanelControl import dSlidePanelControl
-        from dabo.ui.dToggleButton import dToggleButton
-        if isinstance(self, (dMenuItem, dSeparatorMenuItem)):
-            # Hack: wx.MenuItem doesn't take a style arg,
-            # and the parent arg is parentMenu.
-            del preProps["style"]
-            del preProps["parent"]
-            if "kind" in kwargs:
-                preProps["kind"] = kwargs.pop("kind")
-            if "text" in kwargs:
-                preProps["text"] = kwargs.pop("text")
-            if isinstance(self, dSeparatorMenuItem):
-                del(preProps["id"])
-                for remove in ("HelpText", "Icon", "kind"):
-                    self._extractKey((properties, self._properties, kwargs), remove)
-        elif isinstance(self, (dMenu, dMenuBar)):
-            # Hack: wx.Menu has no style, parent, or id arg.
-            del(preProps["style"])
-            del(preProps["id"])
-            del(preProps["parent"])
-        elif isinstance(self, (wx.Timer, )):
-            del(preProps["style"])
-            del(preProps["id"])
-            del(preProps["parent"])
-        elif isinstance(self, (dSlidePanel, dSlidePanelControl)):
-            # Hack: the Slide Panel classes have no style arg.
-            del preProps["style"]
-            # This is needed because these classes require a 'parent' param.
-            kwargs["parent"] = preProps["parent"]
-        elif isinstance(self, (wx.lib.platebtn.PlateButton)):
-            preProps["id_"] = preProps["id"]
-            del preProps["id"]
-        # Add the kwargs to the preProps
-        preProps.update(kwargs)
-        return preProps, kwargs
+    def _initEvents(self):
+        super(dPemMixin, self)._initEvents()
+        self.autoBindEvents()
+
+    def _initUI(self):
+        """Abstract method: subclasses MUST override for UI-specifics."""
+        pass
 
 
     def getPropertyInfo(cls, name):
         """Abstract method: subclasses MUST override for UI-specifics."""
         return super(dPemMixin, cls).getPropertyInfo(name)
     getPropertyInfo = classmethod(getPropertyInfo)
+
+
+    def addObject(self, classRef, Name=None, *args, **kwargs):
+        """
+        Create an instance of classRef, and make it a child of self.
+
+        Abstract method: subclasses MUST override for UI-specifics.
+        """
+        pass
+
+
+    def reCreate(self, child=None):
+        """Abstract method: subclasses MUST override for UI-specifics."""
+        pass
+
+
+    def clone(self, obj, name=None):
+        """Abstract method: subclasses MUST override for UI-specifics."""
+        pass
+
+    def refresh(self):
+        """Abstract method."""
+        pass
 
 
     def _initName(self, name=None, _explicitName=True):
@@ -294,8 +340,7 @@ class dPemMixin(dObject):
             self.FontSize = fontSize
         dabo.ui.callAfterInterval(200, self.refresh)
 
-        from dabo.ui.dFormMixin import dFormMixin
-        if isinstance(self, dFormMixin):
+        if isinstance(self, dabo.ui.dFormMixin):
             frm = self
         else:
             frm = self.Form
@@ -359,10 +404,10 @@ class dPemMixin(dObject):
             return False
 
 
-    def _beforeInit(self):
+    def _beforeInit(self, pre):
         self._acceleratorTable = {}
         self._name = "?"
-        self._pemObject = None
+        self._pemObject = pre
         self._needRedraw = True
         self._inRedraw = False
         self._borderColor = (0, 0, 0)
@@ -477,26 +522,24 @@ class dPemMixin(dObject):
 
 
     def _initEvents(self):
-        from dabo.ui.dGrid import dGrid
         # Bind wx events to handlers that re-raise the Dabo events:
         targ = self._EventTarget
 
-        # Bind EVT_WINDOW_DESTROY twice: once to parent, and once to self.
-        # Binding to the parent allows for attribute access of the child in the
-        # dEvents.Destroy handler, in most cases. In some cases (panels at
-        # least), the self binding fires first. We sort it out in
-        # __onWxDestroy, only reacting to the first destroy event.
+        # Bind EVT_WINDOW_DESTROY twice: once to parent, and once to self. Binding
+        # to the parent allows for attribute access of the child in the dEvents.Destroy
+        # handler, in most cases. In some cases (panels at least), the self binding fires
+        # first. We sort it out in __onWxDestroy, only reacting to the first destroy
+        # event.
         parent = self.GetParent()
         if parent:
             parent.Bind(wx.EVT_WINDOW_DESTROY, self.__onWxDestroy)
         self.Bind(wx.EVT_WINDOW_DESTROY, self.__onWxDestroy)
         self.Bind(wx.EVT_IDLE, self.__onWxIdle)
         self.Bind(wx.EVT_MENU_OPEN, targ.__onWxMenuOpen)
-        print("BINDING MENUOPEN TO", targ, "SELF", self)
 
-        if isinstance(self, dGrid):
-            # Ugly workaround for grids not firing focus events from the
-            # keyboard correctly.
+        if isinstance(self, dui.dGrid):
+            ## Ugly workaround for grids not firing focus events from the keyboard
+            ## correctly.
             self._lastGridFocusTimestamp = 0.0
             self.GetGridCornerLabelWindow().Bind(wx.EVT_SET_FOCUS, self.__onWxGotFocus)
             self.GetGridColLabelWindow().Bind(wx.EVT_SET_FOCUS, self.__onWxGotFocus)
@@ -661,23 +704,20 @@ class dPemMixin(dObject):
 
 
     def __onWxMenuOpen(self, evt):
-        from dabo.ui.dMenu import dMenu
         menu = evt.GetMenu()
-        if menu and isinstance(menu, dMenu):
-            print("RAISING MENUOPEN", menu)
+        if menu and isinstance(menu, dui.dMenu):
             menu.raiseEvent(dEvents.MenuOpen, evt)
         evt.Skip()
 
 
     def __onWxGotFocus(self, evt):
-        from dabo.ui.dGrid import dGrid
         try:
             self.Form._controlGotFocus(self)
         except AttributeError:
             # 'Form' is None
             pass
         self._pushStatusText()
-        if isinstance(self, dGrid):
+        if isinstance(self, dui.dGrid):
             ## Continuation of ugly workaround for grid focus event. Only raise the
             ## Dabo event if we are reasonably sure it isn't a repeat.
             prev = self._lastGridFocusTimestamp
@@ -688,8 +728,7 @@ class dPemMixin(dObject):
 
 
     def __onWxKeyChar(self, evt):
-        from dabo.ui.dComboBox import dComboBox
-        if not (isinstance(self, dComboBox) and evt.KeyCode == 9):
+        if not (isinstance(self, dui.dComboBox) and evt.KeyCode == 9):
             self.raiseEvent(dEvents.KeyChar, evt)
 
 
@@ -826,8 +865,7 @@ class dPemMixin(dObject):
         if self._finito:
             return
         self._needRedraw = bool(self._drawnObjects)
-        from dabo.ui.dFormMixin import dFormMixin
-        if sys.platform.startswith("win") and isinstance(self, dFormMixin):
+        if sys.platform.startswith("win") and isinstance(self, dui.dFormMixin):
             dui.callAfterInterval(200, self.update)
         self.raiseEvent(dEvents.Resize, evt)
 
@@ -1108,9 +1146,9 @@ class dPemMixin(dObject):
         If this object is inside of any paged control, it will force all containing
         paged controls to switch to the page that contains this object.
         """
-        from dabo.ui.dialogs.WizardPage import WizardPage
+        import dui.dialogs
         cntnr = self.getContainingPage()
-        if isinstance(cntnr, WizardPage):
+        if isinstance(cntnr, dui.dialogs.WizardPage):
             self.Form.CurrentPage = cntnr
         else:
             cntnr.Parent.SelectedPage = cntnr
@@ -1120,18 +1158,15 @@ class dPemMixin(dObject):
         """
         Return the dPage or WizardPage that contains self.
         """
-        from dabo.ui.dForm import dForm
-        from dabo.ui.dPage import dPage
-        from dabo.ui.dialogs.Wizard import Wizard
-        from dabo.ui.dialogs.WizardPage import WizardPage
+        import dui.dialogs
         try:
             frm = self.Form
         except AttributeError:
             frm = None
         cntnr = self
-        iswiz = isinstance(frm, Wizard)
-        mtch = {True: WizardPage, False: dPage}[iswiz]
-        while cntnr and not isinstance(cntnr, dForm):
+        iswiz = isinstance(frm, dui.dialogs.Wizard)
+        mtch = {True: dui.dialogs.WizardPage, False: dui.dPage}[iswiz]
+        while cntnr and not isinstance(cntnr, dui.dForm):
             if isinstance(cntnr, mtch):
                 return cntnr
             cntnr = cntnr.Parent
@@ -1191,8 +1226,7 @@ class dPemMixin(dObject):
         to the containing form. If no position is passed, returns the position
         of this control relative to the form.
         """
-        from dabo.ui.dFormMixin import dFormMixin
-        if isinstance(self, dFormMixin):
+        if isinstance(self, dui.dFormMixin):
             frm = self.Parent
         else:
             frm = self.Form
@@ -1207,9 +1241,8 @@ class dPemMixin(dObject):
         to the specified container. If no position is passed, returns the position
         of this control relative to the container.
         """
-        from dabo.ui.dFormMixin import dFormMixin
         selfX, selfY = self.absoluteCoordinates()
-        if self.Application.Platform == "Win" and isinstance(cnt, dFormMixin):
+        if self.Application.Platform == "Win" and isinstance(cnt, dui.dFormMixin):
             # On Windows, absoluteCoordinates() returns the position of the
             # interior of the form, ignoring the menus, borders, etc. On Mac, it
             # properly returns position of the entire window frame
@@ -1226,10 +1259,9 @@ class dPemMixin(dObject):
         to this object. If no position is passed, returns the position
         of this control relative to the form.
         """
-        from dabo.ui.dFormMixin import dFormMixin
         if pos is None:
             pos = self.absoluteCoordinates()
-        if isinstance(self, dFormMixin):
+        if isinstance(self, dui.dFormMixin):
             return pos
         x, y = pos
         formX, formY = self.Form.absoluteCoordinates()
@@ -1238,9 +1270,8 @@ class dPemMixin(dObject):
 
     def absoluteCoordinates(self, pos=None):
         """Translates a position value for a control to absolute screen position."""
-        from dabo.ui.dFormMixin import dFormMixin
         if pos is None:
-            if isinstance(self, dFormMixin):
+            if isinstance(self, dui.dFormMixin):
                 pos = (0, 0)
             else:
                 pos = self.Position
@@ -1348,18 +1379,14 @@ class dPemMixin(dObject):
         object is prefixed to the expression. For example, if you want to only
         affect objects that are instances of dButton, you'd call::
 
-            form.setAll("FontBold", True, filt="BaseClass == dButton")
+            form.setAll("FontBold", True, filt="BaseClass == dui.dButton")
 
         If the instancesOf sequence is passed, the property will only be set if
         the child object is an instance of one of the passed classes.
         """
-        from dabo.ui.dGrid import dColumn
-        from dabo.ui.dGrid import dGrid
-        from dabo.ui.dPageFrameMixin import dPageFrameMixin
-        from dabo.ui.dPageFrameNoTabs import dPageFrameNoTabs
-        if isinstance(self, dGrid):
+        if isinstance(self, dui.dGrid):
             kids = self.Columns
-        elif isinstance(self, (dPageFrameMixin, dPageFrameNoTabs)):
+        elif isinstance(self, (dui.dPageFrameMixin, dui.dPageFrameNoTabs)):
             kids = self.Pages
         else:
             kids = self.Children
@@ -1393,7 +1420,7 @@ class dPemMixin(dObject):
                             break
             if ok:
                 setProp(kid, prop, val)
-                if isinstance(kid, dColumn):
+                if isinstance(kid, dui.dColumn):
                     setProp(kid, "Header%s" % prop, val)
             if recurse:
                 if hasattr(kid, "setAll"):
@@ -1458,13 +1485,11 @@ class dPemMixin(dObject):
 
     def __onUpdate(self, evt):
         """Update any dynamic properties, and then call the update() hook."""
-        from dabo.ui.dFormMixin import dFormMixin
-        from dabo.ui.dPageFrameMixin import dPageFrameMixin
-        if not(self) or not self._constructed():
+        if isinstance(self, dui.deadObject) or not self._constructed():
             return
         # Check paged controls event propagation to inactive pages.
         try:
-            isPage = isinstance(self.Parent, dPageFrameMixin)
+            isPage = isinstance(self.Parent, dui.dPageFrameMixin)
         except AttributeError:
             isPage = False
         if isPage:
@@ -1477,7 +1502,7 @@ class dPemMixin(dObject):
             if not updateInactive and not self.Visible:
                 # (some platforms have inactive pages not visible)
                 return
-        if isinstance(self, dFormMixin) and not self.Visible:
+        if isinstance(self, dui.dFormMixin) and not self.Visible:
             return
         self.update()
 
@@ -1491,12 +1516,11 @@ class dPemMixin(dObject):
 
     def update(self):
         """Update the properties of this object and all contained objects."""
-        from dabo.ui.dForm import dForm
-        if not(self):
+        if isinstance(self, dui.deadObject):
             # This can happen if an object is released when there is a
             # pending callAfter() refresh.
             return
-        if isinstance(self, dForm) and self.AutoUpdateStatusText \
+        if isinstance(self, dui.dForm) and self.AutoUpdateStatusText \
                 and self.Visible:
             self.setStatusText(self.getCurrentRecordText(), immediate=True)
         if self.Children:
@@ -1527,7 +1551,7 @@ class dPemMixin(dObject):
         """Repaints this control and all contained objects."""
         try:
             self.Refresh()
-        except RuntimeError:
+        except dui.deadObjectException:
             # This can happen if an object is released when there is a
             # pending callAfter() refresh.
             pass
@@ -1566,16 +1590,13 @@ class dPemMixin(dObject):
 
     def getCaptureBitmap(self):
         """Return a bitmap snapshot of self as it appears in the UI at this moment."""
-        from dabo.ui.dForm import dForm
-        from dabo.ui.dDialog import dDialog
-        from dabo.ui.dPanel import dPanel
         obj = self.Parent
         if self.Parent is None:
             obj = self
         offset = 0
         htReduction = 0
         cltTop = self.absoluteCoordinates(self.GetClientAreaOrigin())[1]
-        if isinstance(self, (dForm, dDialog, dPanel)):
+        if isinstance(self, (dui.dForm, dui.dDialog, dui.dPanel)):
             dc = wx.WindowDC(self)
             if self.Application.Platform == "Mac":
                 # Need to adjust for the title bar
@@ -2020,6 +2041,7 @@ class dPemMixin(dObject):
             if i:
                 candidate = "%s%s" % (name, i)
             nameError = hasattr(parent, candidate) \
+                    and type(getattr(parent, candidate)) != wx._core._wxPyDeadObject \
                     and getattr(parent, candidate) != self \
                     and [win for win in parent.GetChildren()
                         if win != self and win.GetName() == candidate]
@@ -2194,15 +2216,13 @@ class dPemMixin(dObject):
         return getattr(self, "_caption", self.GetLabel())
 
     def _setCaption(self, val):
-        from dabo.ui.dEditBox import dEditBox
-        from dabo.ui.dTextBox import dTextBox
         # Force the value to string
         val = "%s" % val
         def __captionSet(val):
             """Windows textboxes change their value when SetLabel() is called; this
             avoids that problem.
             """
-            if not isinstance(self, (dTextBox, dEditBox)):
+            if not isinstance(self, (dui.dTextBox, dui.dEditBox)):
                 self._caption = val
                 uval = ustr(val)
                 ## 2/23/2005: there is a bug in wxGTK that resets the font when the
@@ -2269,12 +2289,11 @@ class dPemMixin(dObject):
         return self._droppedFileHandler
 
     def _setDroppedFileHandler(self, val):
-        from dabo.ui.dGrid import dGrid
         if self._constructed():
             self._droppedFileHandler = val
             if self._dropTarget == None:
                 self._dropTarget = _DropTarget()
-                if isinstance(self, dGrid):
+                if isinstance(self, dui.dGrid):
                     wxObj = self.GetGridWindow()
                 else:
                     wxObj = self
@@ -2288,12 +2307,11 @@ class dPemMixin(dObject):
         return self._droppedTextHandler
 
     def _setDroppedTextHandler(self, val):
-        from dabo.ui.dGrid import dGrid
         if self._constructed():
             self._droppedTextHandler = val
             if self._dropTarget == None:
                 self._dropTarget = _DropTarget()
-                if isinstance(self, dGrid):
+                if isinstance(self, dui.dGrid):
                     wxObj = self.GetGridWindow()
                 else:
                     wxObj = self
@@ -2334,18 +2352,16 @@ class dPemMixin(dObject):
 
 
     def _getDaboFont(self):
-        from dabo.ui.dFont import dFont
-        if hasattr(self, "_font") and isinstance(self._font, dFont):
+        if hasattr(self, "_font") and isinstance(self._font, dui.dFont):
             v = self._font
         else:
-            v = self.Font = dFont(_nativeFont=self.GetFont())
+            v = self.Font = dui.dFont(_nativeFont=self.GetFont())
         return v
 
     def _setDaboFont(self, val):
-        from dabo.ui.dFont import dFont
         #PVG: also accep wxFont parameter
-        if isinstance(val, wx.Font):
-            val = dFont(_nativeFont=val)
+        if isinstance(val, (wx.Font, wx._gdi.Font)):
+            val = dui.dFont(_nativeFont=val)
         if self._constructed():
             self._font = val
             try:
@@ -2436,14 +2452,14 @@ class dPemMixin(dObject):
         try:
             return self._cachedForm
         except AttributeError:
-            from dabo.ui.dFormMixin import dFormMixin
+            import dabo.ui
             obj, frm = self, None
             while obj:
                 try:
                     parent = obj.Parent
                 except AttributeError:
                     break
-                if isinstance(parent, (dFormMixin)):
+                if isinstance(parent, (dabo.ui.dFormMixin)):
                     frm = parent
                     break
                 else:
@@ -2457,7 +2473,6 @@ class dPemMixin(dObject):
         return self.GetSize()[1]
 
     def _setHeight(self, val):
-        from dabo.ui.dFormMixin import dFormMixin
         if self._constructed():
             if getattr(self, "_widthAlreadySet", False):
                 width = self.Width
@@ -2465,7 +2480,7 @@ class dPemMixin(dObject):
                 width = -1
             newSize = (width, int(val))
             self._setSize(newSize)
-            if isinstance(self, dFormMixin):
+            if isinstance(self, dui.dFormMixin):
                 self._defaultHeight = val
         else:
             self._properties["Height"] = val
@@ -2492,10 +2507,9 @@ class dPemMixin(dObject):
         return self.GetPosition()[0]
 
     def _setLeft(self, val):
-        from dabo.ui.dFormMixin import dFormMixin
         if self._constructed():
             self.SetPosition((int(val), self.Top))
-        if isinstance(self, dFormMixin):
+        if isinstance(self, dui.dFormMixin):
             self._defaultLeft = val
         else:
             self._properties["Left"] = val
@@ -2652,8 +2666,9 @@ class dPemMixin(dObject):
 
                 # Make sure that the name isn't already used
                 if self.Parent:
-                    if (hasattr(self.Parent, name) and
-                            getattr(self.Parent, name) != self):
+                    if hasattr(self.Parent, name) \
+                            and type(getattr(self.Parent, name)) != wx._core._wxPyDeadObject \
+                            and getattr(self.Parent, name) != self:
                         raise NameError("Name '%s' is already in use." % name)
                 try:
                     self.Parent.__dict__[name] = self
@@ -2671,8 +2686,9 @@ class dPemMixin(dObject):
                 else:
                     # the user is explicitly setting the Name. If another object already
                     # has the name, we must raise an exception immediately.
-                    if (hasattr(parent, name) and
-                            getattr(parent, name) != self):
+                    if hasattr(parent, name) \
+                            and type(getattr(parent, name)) != wx._core._wxPyDeadObject \
+                            and getattr(parent, name) != self:
                         raise NameError("Name '%s' is already in use." % name)
                     else:
                         for window in parent.GetChildren():
@@ -2747,10 +2763,9 @@ class dPemMixin(dObject):
         return self.GetPosition().Get()
 
     def _setPosition(self, val):
-        from dabo.ui.dFormMixin import dFormMixin
         if self._constructed():
             left, top = val
-            if isinstance(self, dFormMixin):
+            if isinstance(self, dui.dFormMixin):
                 self._defaultLeft, self._defaultTop = (left, top)
             self.SetPosition((left, top))
         else:
@@ -2793,7 +2808,6 @@ class dPemMixin(dObject):
         return self.GetSize().Get()
 
     def _setSize(self, val):
-        from dabo.ui.dFormMixin import dFormMixin
         if self._constructed():
             self._widthAlreadySet = (val[0] >= 0)
             self._heightAlreadySet = (val[1] >= 0)
@@ -2808,7 +2822,7 @@ class dPemMixin(dObject):
                 else:
                     # prior to wxPython 2.7.s:
                     self.SetBestFittingSize(val)
-            if isinstance(self, dFormMixin):
+            if isinstance(self, dui.dFormMixin):
                 self._defaultWidth, self._defaultHeight = val
         else:
             self._properties["Size"] = val
@@ -2888,9 +2902,8 @@ class dPemMixin(dObject):
         return self.GetPosition()[1]
 
     def _setTop(self, val):
-        from dabo.ui.dFormMixin import dFormMixin
         if self._constructed():
-            if isinstance(self, dFormMixin):
+            if isinstance(self, dui.dFormMixin):
                 self._defaultTop = val
             self.SetPosition((self.Left, int(val)))
         else:
@@ -2963,7 +2976,6 @@ class dPemMixin(dObject):
         return self.GetSize()[0]
 
     def _setWidth(self, val):
-        from dabo.ui.dFormMixin import dFormMixin
         if self._constructed():
             if getattr(self, "_heightAlreadySet", False):
                 height = self.Height
@@ -2971,7 +2983,7 @@ class dPemMixin(dObject):
                 height = -1
             newSize = (int(val), height)
             self._setSize(newSize)
-            if isinstance(self, dFormMixin):
+            if isinstance(self, dui.dFormMixin):
                 self._defaultWidth = val
         else:
             self._properties["Width"] = val
@@ -3322,11 +3334,10 @@ class DrawObject(dObject):
         called except as part of a method of the parent that first clears the
         background.
         """
-        from dabo.ui.dFormMixin import dFormMixin
         if not self.Visible or self._inInit:
             return
         srcObj = self.Parent
-        if isinstance(srcObj, dFormMixin):
+        if isinstance(srcObj, dui.dFormMixin):
             frm = srcObj
         else:
             frm = srcObj.Form

--- a/dabo/ui/dPemMixin.py
+++ b/dabo/ui/dPemMixin.py
@@ -60,6 +60,7 @@ class dPemMixin(dObject):
         from dabo.ui.dMenuBar import dMenuBar
         if threeWayInit:
             # Instantiate the wx Pre object
+            print("3WAY", preClass)
             pre = preClass()
         else:
             pre = None
@@ -182,6 +183,7 @@ class dPemMixin(dObject):
         # Do the init:
         if threeWayInit:
             preKwargs = self._preInitProperties
+            print("PRECREATE", args, preKwargs, self)
             pre.Create(parent, *args, **preKwargs)
         elif preClass is None:
             pass
@@ -191,6 +193,7 @@ class dPemMixin(dObject):
         if threeWayInit:
             self.PostCreate(pre)
 
+        print("SUPERPEM KWARGS", kwargs, self)
         super(dPemMixin, self).__init__(parent=parent, *args, **kwargs)
         self._pemObject = self
 
@@ -224,6 +227,7 @@ class dPemMixin(dObject):
 
         # Finally, at the end of the init cycle, raise the Create event
         self.raiseEvent(dEvents.Create)
+        print("PEMINIT DONE", self)
 
 
     def getPropertyInfo(cls, name):
@@ -445,6 +449,7 @@ class dPemMixin(dObject):
 
 
     def _afterInit(self):
+        print("_AFTERINIT", self)
         if not wx.HelpProvider.Get():
             # The app hasn't set a help provider, and one is needed
             # to be able to save/restore help text.
@@ -458,14 +463,8 @@ class dPemMixin(dObject):
         """This is the framework-level hook. It calls the developer-specific method."""
         if not self:
             return
-        print("AFTERINITALL CALLED", self)
         self.afterInitAll()
-        print("AFTERINITALL DONE", self)
-
-
-    def afterInitAll(self):
-        #pass
-        print("AFTERINITALL NOOP", self)
+    def afterInitAll(self): pass
 
 
     def _preInitUI(self, kwargs):
@@ -519,6 +518,7 @@ class dPemMixin(dObject):
         self.Bind(wx.EVT_WINDOW_DESTROY, self.__onWxDestroy)
         self.Bind(wx.EVT_IDLE, self.__onWxIdle)
         self.Bind(wx.EVT_MENU_OPEN, targ.__onWxMenuOpen)
+        print("BINDING MENUOPEN TO", targ, "SELF", self)
 
         if isinstance(self, dGrid):
             # Ugly workaround for grids not firing focus events from the
@@ -590,7 +590,6 @@ class dPemMixin(dObject):
 
 
     def _bindDelayed(self):
-        dabo.trace()
         for evt, mthdString in self._delayedEventBindings:
             if not mthdString:
                 # Empty method string; this is a sign of a bug in the UI code.
@@ -691,6 +690,7 @@ class dPemMixin(dObject):
         from dabo.ui.dMenu import dMenu
         menu = evt.GetMenu()
         if menu and isinstance(menu, dMenu):
+            print("RAISING MENUOPEN", menu)
             menu.raiseEvent(dEvents.MenuOpen, evt)
         evt.Skip()
 
@@ -1532,7 +1532,6 @@ class dPemMixin(dObject):
 
     def __updateDynamicProps(self):
         """Updates the object's dynamic properties."""
-        dabo.trace()
         if not self:
             return
         self.__updateObjectDynamicProps(self)
@@ -4143,7 +4142,7 @@ class DrawObject(dObject):
 class _DropTarget(wx.DropTarget):
     """Class that handles drag/drop items of any type."""
     def __init__(self):
-        super(_DropTarget, self).__init__()
+        wx.DropTarget.__init__(self)
 
         self._fileHandle  = self._textHandle = None
         self.compositeDataObject = wx.DataObjectComposite()

--- a/dabo/ui/dProgressDialog.py
+++ b/dabo/ui/dProgressDialog.py
@@ -47,7 +47,7 @@ class ResultEvent(wx.PyEvent):
     """Simple event to carry arbitrary result data."""
 
     def __init__(self, response):
-        super(ResultEvent, self).__init__()
+        wx.PyEvent.__init__(self)
         self.SetEventType(EVT_RESULT_ID)
         self.response = response
 
@@ -55,14 +55,14 @@ class ExceptionEvent(wx.PyEvent):
     """Simple event to carry arbitrary result data."""
 
     def __init__(self, response):
-        super(ExceptionEvent, self).__init__()
+        wx.PyEvent.__init__(self)
         self.SetEventType(EVT_EXCEPTION_ID)
         self.response = response
 
 # Thread class that executes processing
 class WorkerThread(Thread):
     def __init__(self, notify_window, func):
-        super(WorkerThread, self).__init__()
+        Thread.__init__(self)
         self._notify_window = notify_window
         self._want_abort = 0
         self.setDaemon(1)
@@ -104,7 +104,7 @@ class dProgressTimer(wx.Timer):
 # GUI Frame class that spins off the worker thread
 class dProgressDialog(wx.Dialog):
     def __init__(self, parent, caption="Progress Dialog"):
-        super(dProgressDialog, self).__init__(parent, -1, caption)
+        wx.Dialog.__init__(self,parent,-1,caption)
         self.Centre(wx.BOTH)
         self.SetSize((300,100))
         self.status = wx.StaticText(self,-1,'Please Wait...',pos=(0,100))

--- a/dabo/ui/dRadioList.py
+++ b/dabo/ui/dRadioList.py
@@ -17,8 +17,8 @@ class _dRadioButton(dDataControlMixin, wx.RadioButton):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dRadioButton
-        preClass = wx.RadioButton
-        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.RadioButton
+        dDataControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -135,7 +135,7 @@ class dRadioList(dControlItemMixin, wx.Panel):
         self._buttonClass = _dRadioButton
         self._showBox = True
         self._caption = ""
-        preClass = wx.Panel
+        wxClass = wx.Panel
         style = self._extractKey((properties, attProperties, kwargs), "style", 0)
         style = style | wx.TAB_TRAVERSAL
         kwargs["style"] = style
@@ -149,7 +149,7 @@ class dRadioList(dControlItemMixin, wx.Panel):
         # 'ButtonSpacing' property.
         self._buttonSpacing = 5
 
-        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
+        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dRadioList.py
+++ b/dabo/ui/dRadioList.py
@@ -18,9 +18,8 @@ class _dRadioButton(dDataControlMixin, wx.RadioButton):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dRadioButton
         preClass = wx.RadioButton
-        super(_dRadioButton, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initEvents(self):
@@ -150,7 +149,7 @@ class dRadioList(dControlItemMixin, wx.Panel):
         # 'ButtonSpacing' property.
         self._buttonSpacing = 5
 
-        super(dRadioList, self).__init__(preClass, parent=parent, properties=properties,
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dRadioList.py
+++ b/dabo/ui/dRadioList.py
@@ -17,7 +17,7 @@ class _dRadioButton(dDataControlMixin, wx.RadioButton):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dRadioButton
-        preClass = wx.PreRadioButton
+        preClass = wx.RadioButton
         dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
@@ -135,7 +135,7 @@ class dRadioList(dControlItemMixin, wx.Panel):
         self._buttonClass = _dRadioButton
         self._showBox = True
         self._caption = ""
-        preClass = wx.PrePanel
+        preClass = wx.Panel
         style = self._extractKey((properties, attProperties, kwargs), "style", 0)
         style = style | wx.TAB_TRAVERSAL
         kwargs["style"] = style

--- a/dabo/ui/dRadioList.py
+++ b/dabo/ui/dRadioList.py
@@ -17,8 +17,8 @@ class _dRadioButton(dDataControlMixin, wx.RadioButton):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dRadioButton
-        wxClass = wx.RadioButton
-        dDataControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreRadioButton
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -135,7 +135,7 @@ class dRadioList(dControlItemMixin, wx.Panel):
         self._buttonClass = _dRadioButton
         self._showBox = True
         self._caption = ""
-        wxClass = wx.Panel
+        preClass = wx.PrePanel
         style = self._extractKey((properties, attProperties, kwargs), "style", 0)
         style = style | wx.TAB_TRAVERSAL
         kwargs["style"] = style
@@ -149,7 +149,7 @@ class dRadioList(dControlItemMixin, wx.Panel):
         # 'ButtonSpacing' property.
         self._buttonSpacing = 5
 
-        dControlItemMixin.__init__(self, wxClass, parent, properties=properties,
+        dControlItemMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dRichTextBox.py
+++ b/dabo/ui/dRichTextBox.py
@@ -32,9 +32,8 @@ class dRichTextBox(dDataControlMixin, wx.richtext.RichTextCtrl):
         self._htmlHandler = wx.richtext.RichTextHTMLHandler()
         self._handlers = (self._xmlHandler, self._htmlHandler)
         preClass = wx.richtext.PreRichTextCtrl
-        super(dRichTextBox, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def load(self, fileOrObj=None):

--- a/dabo/ui/dSearchBox.py
+++ b/dabo/ui/dSearchBox.py
@@ -16,9 +16,8 @@ class dSearchBox(dTextBoxMixin, wx.SearchCtrl):
         self._cancelVisible = False
         self._searchVisible = True
         preClass = wx.SearchCtrl
-        super(dSearchBox, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
     def _initEvents(self):
         super(dSearchBox, self)._initEvents()

--- a/dabo/ui/dSearchBox.py
+++ b/dabo/ui/dSearchBox.py
@@ -15,8 +15,8 @@ class dSearchBox(dTextBoxMixin, wx.SearchCtrl):
         self._list = []
         self._cancelVisible = False
         self._searchVisible = True
-        wxClass = wx.SearchCtrl
-        dTextBoxMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreSearchCtrl
+        dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def _initEvents(self):

--- a/dabo/ui/dSearchBox.py
+++ b/dabo/ui/dSearchBox.py
@@ -15,8 +15,8 @@ class dSearchBox(dTextBoxMixin, wx.SearchCtrl):
         self._list = []
         self._cancelVisible = False
         self._searchVisible = True
-        preClass = wx.SearchCtrl
-        dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.SearchCtrl
+        dTextBoxMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
     def _initEvents(self):

--- a/dabo/ui/dSearchBox.py
+++ b/dabo/ui/dSearchBox.py
@@ -15,7 +15,7 @@ class dSearchBox(dTextBoxMixin, wx.SearchCtrl):
         self._list = []
         self._cancelVisible = False
         self._searchVisible = True
-        preClass = wx.PreSearchCtrl
+        preClass = wx.SearchCtrl
         dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dShell.py
+++ b/dabo/ui/dShell.py
@@ -369,18 +369,19 @@ class dShell(dControlMixin, wx.py.shell.Shell):
             _("Size of the font used in the shell  (int)"))
 
 
+
 class dShellForm(dSplitForm):
     def _onDestroy(self, evt):
         self._clearOldHistory()
-        builtins.input = self._oldInput
+        builtins.raw_input = self._oldRawInput
 
 
-    def _beforeInit(self):
+    def _beforeInit(self, pre):
         # Set the sash
         self._sashPct = 0.6
         # Class to use for creating the interactive shell
         self._shellClass = dShell
-        super(dShellForm, self)._beforeInit()
+        super(dShellForm, self)._beforeInit(pre)
 
 
     def _afterInit(self):
@@ -389,11 +390,11 @@ class dShellForm(dSplitForm):
         self._historyPanel = None
         self._lastCmd = None
 
-        # PyShell sets the input function to a function of PyShell,
+        # PyShell sets the raw_input function to a function of PyShell,
         # but doesn't set it back on destroy, resulting in errors later
-        # on if something other than PyShell asks for input (pdb, for
+        # on if something other than PyShell asks for raw_input (pdb, for
         # example).
-        self._oldInput = builtins.input
+        self._oldRawInput = builtins.raw_input
         self.bindEvent(dEvents.Destroy, self._onDestroy)
 
         splt = self.Splitter
@@ -431,7 +432,7 @@ class dShellForm(dSplitForm):
         # This lets you go all the way back to the '.' without losing the AutoComplete
         self.shell.AutoCompSetCancelAtStart(False)
         self.shell.Bind(wx.EVT_RIGHT_UP, self.onShellRight)
-        self.shell.Bind(wx.EVT_CONTEXT_MENU, self.onShellContext)
+        self.shell.Bind(wx.wx.EVT_CONTEXT_MENU, self.onShellContext)
 
         # Create the Code control
         codeControl = dEditor(self.pgCode, RegID="edtCode",

--- a/dabo/ui/dShell.py
+++ b/dabo/ui/dShell.py
@@ -175,9 +175,8 @@ class dShell(dControlMixin, wx.py.shell.Shell):
             self._fontSize = 10
         self._baseClass = dShell
         preClass = wx.py.shell.Shell
-        super(dShell, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     @dabo.ui.deadCheck

--- a/dabo/ui/dSizer.py
+++ b/dabo/ui/dSizer.py
@@ -26,6 +26,7 @@ class dSizer(dSizerMixin, wx.BoxSizer):
             orientation = wx.VERTICAL
         else:
             orientation = wx.HORIZONTAL
+        wx.BoxSizer.__init__(self, orientation)
 
         self._properties = {}
         # The keyword properties can come from either, both, or none of:
@@ -44,7 +45,7 @@ class dSizer(dSizerMixin, wx.BoxSizer):
             bad = ", ".join(list(kwargs.keys()))
             raise TypeError("Invalid keyword arguments passed to dSizer: %s" % bad)
 
-        super(dSizer, self).__init__(orientation=orientation, *args, **kwargs)
+        dSizerMixin.__init__(self, *args, **kwargs)
 
 
     def getBorderedClass(self):

--- a/dabo/ui/dSizerMixin.py
+++ b/dabo/ui/dSizerMixin.py
@@ -236,7 +236,7 @@ class dSizerMixin(dObject):
             itm = self.Add(spacer, proportion=proportion, userData=self)
         else:
             itm = self.Insert(pos, spacer, proportion=proportion, userData=self)
-        itm.setSpacing = itm.AssignSpacer
+        itm.setSpacing = itm.SetSpacer
         return itm
 
 

--- a/dabo/ui/dSizerMixin.py
+++ b/dabo/ui/dSizerMixin.py
@@ -80,7 +80,6 @@ class dSizerMixin(dObject):
 
 
     def __init__(self, *args, **kwargs):
-        kwargs.pop("orientation", None)
         super(dSizerMixin, self).__init__(*args, **kwargs)
 
 

--- a/dabo/ui/dSlidePanelControl.py
+++ b/dabo/ui/dSlidePanelControl.py
@@ -50,9 +50,8 @@ class dSlidePanel(dControlMixin, fpb.FoldPanelItem):
                 "borderonly" : fpb.CAPTIONBAR_RECTANGLE,
                 "filledborder" : fpb.CAPTIONBAR_FILLED_RECTANGLE}
 
-        super(dSlidePanel, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         self._cont.appendPanel(self)
         self._cont.RedisplayFoldPanelItems()
@@ -408,9 +407,8 @@ class dSlidePanelControl(dControlMixin, fpb.FoldPanelBar):
         # Ensures that the control has a minimum size.
         self._minSizerWidth = self._minSizerHeight = 100
 
-        super(dSlidePanelControl, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         self._setInitialOpenPanel()
         self.bindEvent(dEvents.SlidePanelChange, self.__onSlidePanelChange)

--- a/dabo/ui/dSlider.py
+++ b/dabo/ui/dSlider.py
@@ -26,8 +26,8 @@ class dSlider(dDataControlMixin, wx.Slider):
         self._tickPosition = None
         self._reversed = False
 
-        preClass = wx.Slider
-        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.Slider
+        dDataControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dSlider.py
+++ b/dabo/ui/dSlider.py
@@ -26,7 +26,7 @@ class dSlider(dDataControlMixin, wx.Slider):
         self._tickPosition = None
         self._reversed = False
 
-        preClass = wx.PreSlider
+        preClass = wx.Slider
         dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 

--- a/dabo/ui/dSlider.py
+++ b/dabo/ui/dSlider.py
@@ -27,7 +27,7 @@ class dSlider(dDataControlMixin, wx.Slider):
         self._reversed = False
 
         preClass = wx.Slider
-        super(dSlider, self).__init__(preClass, parent=parent, properties=properties,
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dSlider.py
+++ b/dabo/ui/dSlider.py
@@ -26,8 +26,8 @@ class dSlider(dDataControlMixin, wx.Slider):
         self._tickPosition = None
         self._reversed = False
 
-        wxClass = wx.Slider
-        dDataControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreSlider
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dSpinner.py
+++ b/dabo/ui/dSpinner.py
@@ -23,7 +23,7 @@ class _dSpinButton(dDataControlMixin, wx.SpinButton):
     """Simple wrapper around the base wx.SpinButton."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dSpinButton
-        preClass = wx.PreSpinButton
+        preClass = wx.SpinButton
         kwargs["style"] = kwargs.get("style", 0) | wx.SP_ARROW_KEYS
         dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)

--- a/dabo/ui/dSpinner.py
+++ b/dabo/ui/dSpinner.py
@@ -25,9 +25,8 @@ class _dSpinButton(dDataControlMixin, wx.SpinButton):
         self._baseClass = _dSpinButton
         preClass = wx.SpinButton
         kwargs["style"] = kwargs.get("style", 0) | wx.SP_ARROW_KEYS
-        super(_dSpinButton, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
         if sys.platform.startswith("win"):
             # otherwise, the arrows are way too wide (34)
             self.Width = 17
@@ -46,7 +45,7 @@ class dSpinner(dDataPanel, wx.Control):
         nm = self._extractKey((properties, attProperties, kwargs), "NameBase", "")
         if not nm:
             nm = self._extractKey((properties, attProperties, kwargs), "Name", "dSpinner")
-        super(dSpinner, self).__init__(None, parent=parent, properties=properties,
+        super(dSpinner, self).__init__(parent=parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         self._baseClass = dSpinner
         # Create the child controls

--- a/dabo/ui/dSpinner.py
+++ b/dabo/ui/dSpinner.py
@@ -23,9 +23,9 @@ class _dSpinButton(dDataControlMixin, wx.SpinButton):
     """Simple wrapper around the base wx.SpinButton."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dSpinButton
-        wxClass = wx.SpinButton
+        preClass = wx.PreSpinButton
         kwargs["style"] = kwargs.get("style", 0) | wx.SP_ARROW_KEYS
-        dDataControlMixin.__init__(self, wxClass, parent, properties=properties,
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         if sys.platform.startswith("win"):
             # otherwise, the arrows are way too wide (34)

--- a/dabo/ui/dSpinner.py
+++ b/dabo/ui/dSpinner.py
@@ -23,9 +23,9 @@ class _dSpinButton(dDataControlMixin, wx.SpinButton):
     """Simple wrapper around the base wx.SpinButton."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = _dSpinButton
-        preClass = wx.SpinButton
+        wxClass = wx.SpinButton
         kwargs["style"] = kwargs.get("style", 0) | wx.SP_ARROW_KEYS
-        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+        dDataControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
         if sys.platform.startswith("win"):
             # otherwise, the arrows are way too wide (34)

--- a/dabo/ui/dSplitter.py
+++ b/dabo/ui/dSplitter.py
@@ -144,7 +144,7 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         # Default to not showing the context menus on the panels
         self._showPanelSplitMenu = False
 
-        preClass = wx.PreSplitterWindow
+        preClass = wx.SplitterWindow
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 

--- a/dabo/ui/dSplitter.py
+++ b/dabo/ui/dSplitter.py
@@ -145,8 +145,8 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         # Default to not showing the context menus on the panels
         self._showPanelSplitMenu = False
 
-        preClass = wx.SplitterWindow
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.SplitterWindow
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 
 

--- a/dabo/ui/dSplitter.py
+++ b/dabo/ui/dSplitter.py
@@ -17,7 +17,6 @@ class SplitterPanelMixin(object):
     def __init__(self, parent, *args, **kwargs):
         if self.ShowSplitMenu:
             self.bindEvent(dEvents.ContextMenu, self._onMixinContextMenu)
-        super(SplitterPanelMixin, self).__init__(parent=parent, *args, **kwargs)
 
 
     def _onMixinContextMenu(self, evt):
@@ -147,9 +146,8 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         self._showPanelSplitMenu = False
 
         preClass = wx.SplitterWindow
-        super(dSplitter, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties,
-                style=style, *args, **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, style=style, *args, **kwargs)
 
 
     def _initEvents(self):
@@ -177,7 +175,8 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         else:
             class MixedSplitterPanel(cls, mixin):
                 def __init__(self, parent, *args, **kwargs):
-                    super(MixedSplitterPanel, self).__init__(parent, *args, **kwargs)
+                    cls.__init__(self, parent, *args, **kwargs)
+                    mixin.__init__(self, parent, *args, **kwargs)
             ret = MixedSplitterPanel
         return ret
 

--- a/dabo/ui/dSplitter.py
+++ b/dabo/ui/dSplitter.py
@@ -8,9 +8,6 @@ from dabo import dEvents as dEvents
 from dabo.dLocalize import _
 from dabo import dColors as dColors
 from dabo.ui.dControlMixin import dControlMixin
-from dabo.ui.dMenu import dMenu
-from dabo.ui.dPanel import dPanel
-from dabo.ui.dSizer import dSizer
 
 
 class SplitterPanelMixin(object):
@@ -23,7 +20,7 @@ class SplitterPanelMixin(object):
         if not self.Parent.ShowPanelSplitMenu:
             return
         evt.stop()
-        sm = dMenu(self)
+        sm = dabo.ui.dMenu(self)
         sm.append("Split this pane", OnHit=self.onSplit)
         if self.Parent.canRemove(self):
             sm.append("Remove this pane", OnHit=self.onRemove)
@@ -61,7 +58,7 @@ class SplitterPanelMixin(object):
         else:
             newDir = "h"
         if self.Sizer is None:
-            self.Sizer = dSizer(newDir)
+            self.Sizer = dabo.ui.dSizer(newDir)
         if dir_ is None:
             dir_ = newDir
         win = dSplitter(self, createPanes=True)
@@ -98,6 +95,8 @@ class SplitterPanelMixin(object):
 
     ShowSplitMenu = property(_getShowSplitMenu, _setShowSplitMenu, None,
             _("Determines if the Split/Unsplit context menu is shown (default=True)  (bool)"))
+
+
 
 
 class dSplitter(dControlMixin, wx.SplitterWindow):
@@ -145,8 +144,8 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         # Default to not showing the context menus on the panels
         self._showPanelSplitMenu = False
 
-        wxClass = wx.SplitterWindow
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreSplitterWindow
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 
 
@@ -193,11 +192,11 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         if p1 and (force or self.Panel1 is None):
             self.Panel1 = spCls(self)
             if self._createSizers:
-                self.Panel1.Sizer = dSizer()
+                self.Panel1.Sizer = dabo.ui.dSizer()
         if p2 and (force or self.Panel2 is None):
             self.Panel2 = spCls(self)
             if self._createSizers:
-                self.Panel2.Sizer = dSizer()
+                self.Panel2.Sizer = dabo.ui.dSizer()
 
 
     def initialize(self, pnl):
@@ -376,7 +375,7 @@ class dSplitter(dControlMixin, wx.SplitterWindow):
         try:
             ret = self._panelClass
         except AttributeError:
-            ret = self._panelClass = dPanel
+            ret = self._panelClass = dabo.ui.dPanel
         return ret
 
     def _setPanelClass(self, val):

--- a/dabo/ui/dStatusBar.py
+++ b/dabo/ui/dStatusBar.py
@@ -15,12 +15,11 @@ class dStatusBar(dControlMixin, wx.StatusBar):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dStatusBar
-        preClass = None
+        preClass = wx.StatusBar
         self._platformIsWindows = (self.Application.Platform == "Win")
         self._fieldCount = 1
-        super(dStatusBar, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def layout(self):

--- a/dabo/ui/dStatusBar.py
+++ b/dabo/ui/dStatusBar.py
@@ -15,10 +15,10 @@ class dStatusBar(dControlMixin, wx.StatusBar):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dStatusBar
-        wxClass = wx.StatusBar
+        preClass = wx.PreStatusBar
         self._platformIsWindows = (self.Application.Platform == "Win")
         self._fieldCount = 1
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dStatusBar.py
+++ b/dabo/ui/dStatusBar.py
@@ -15,10 +15,10 @@ class dStatusBar(dControlMixin, wx.StatusBar):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dStatusBar
-        preClass = wx.StatusBar
+        wxClass = wx.StatusBar
         self._platformIsWindows = (self.Application.Platform == "Win")
         self._fieldCount = 1
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dStatusBar.py
+++ b/dabo/ui/dStatusBar.py
@@ -15,7 +15,7 @@ class dStatusBar(dControlMixin, wx.StatusBar):
     """
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dStatusBar
-        preClass = wx.PreStatusBar
+        preClass = wx.StatusBar
         self._platformIsWindows = (self.Application.Platform == "Win")
         self._fieldCount = 1
         dControlMixin.__init__(self, preClass, parent, properties=properties,

--- a/dabo/ui/dTextBox.py
+++ b/dabo/ui/dTextBox.py
@@ -10,7 +10,7 @@ class dTextBox(dTextBoxMixin, wx.TextCtrl):
     """Creates a text box for editing one line of string data."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dTextBox
-        preClass = wx.PreTextCtrl
+        preClass = wx.TextCtrl
 
         dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)

--- a/dabo/ui/dTextBox.py
+++ b/dabo/ui/dTextBox.py
@@ -10,10 +10,11 @@ class dTextBox(dTextBoxMixin, wx.TextCtrl):
     """Creates a text box for editing one line of string data."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dTextBox
-        wxClass = wx.TextCtrl
+        preClass = wx.PreTextCtrl
 
-        dTextBoxMixin.__init__(self, wxClass, parent, properties=properties,
+        dTextBoxMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
+
 
 
 if __name__ == "__main__":
@@ -68,14 +69,14 @@ if __name__ == "__main__":
         def afterInit(self):
             self.Value = datetime.datetime.now()
 
-    testParms = [IntText, LongText, FloatText, StrText, PWText, BoolText,
-            DateText, DateTimeText]
+    testParms = [IntText, LongText, FloatText, StrText, PWText, BoolText, DateText, DateTimeText]
 
     try:
         import mx.DateTime
         class MxDateTimeText(TestBase):
             def afterInit(self):
                 self.Value = mx.DateTime.now()
+
         testParms.append(MxDateTimeText)
     except ImportError:
         # skip it: mx may not be available
@@ -85,6 +86,8 @@ if __name__ == "__main__":
     class DecimalText(TestBase):
         def afterInit(self):
             self.Value = decimal.Decimal("23.42")
+
     testParms.append(DecimalText)
+
 
     test.Test().runTest(testParms)

--- a/dabo/ui/dTextBox.py
+++ b/dabo/ui/dTextBox.py
@@ -10,9 +10,9 @@ class dTextBox(dTextBoxMixin, wx.TextCtrl):
     """Creates a text box for editing one line of string data."""
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dTextBox
-        preClass = wx.TextCtrl
+        wxClass = wx.TextCtrl
 
-        super(dTextBox, self).__init__(preClass, parent, properties=properties,
+        dTextBoxMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 
@@ -70,6 +70,16 @@ if __name__ == "__main__":
 
     testParms = [IntText, LongText, FloatText, StrText, PWText, BoolText,
             DateText, DateTimeText]
+
+    try:
+        import mx.DateTime
+        class MxDateTimeText(TestBase):
+            def afterInit(self):
+                self.Value = mx.DateTime.now()
+        testParms.append(MxDateTimeText)
+    except ImportError:
+        # skip it: mx may not be available
+        pass
 
     import decimal
     class DecimalText(TestBase):

--- a/dabo/ui/dTextBoxMixin.py
+++ b/dabo/ui/dTextBoxMixin.py
@@ -14,9 +14,9 @@ decimalPoint = None
 
 import wx
 import wx.lib.masked as masked
+import dabo
 from dabo.lib import dates
 from dabo.ui import dKeys
-from dabo.dLocalize import _
 from dabo.lib.utils import ustr
 from dabo import ui as dui
 from dabo.ui.dDataControlMixin import dDataControlMixin

--- a/dabo/ui/dTextBoxMixin.py
+++ b/dabo/ui/dTextBoxMixin.py
@@ -27,7 +27,7 @@ from dabo.ui.dDataControlMixin import dDataControlMixin
 
 
 class dTextBoxMixinBase(dDataControlMixin):
-    def __init__(self, preClass, parent, properties=None, attProperties=None, *args, **kwargs):
+    def __init__(self, wxClass, parent, properties=None, attProperties=None, *args, **kwargs):
         global decimalPoint
         if decimalPoint is None:
             decimalPoint = locale.localeconv()["decimal_point"]
@@ -39,7 +39,7 @@ class dTextBoxMixinBase(dDataControlMixin):
         self._inTextLength = False
         self._flushOnLostFocus = True  ## see dabo.ui.dDataControlMixinBase::flushValue()
 
-        super(dTextBoxMixinBase, self).__init__(preClass, parent,
+        super(dTextBoxMixinBase, self).__init__(wxClass, parent,
                 properties=properties, attProperties=attProperties, *args,
                 **kwargs)
 
@@ -472,11 +472,11 @@ class dTextBoxMixinBase(dDataControlMixin):
 
 
 class dTextBoxMixin(dTextBoxMixinBase):
-    def __init__(self, preClass, parent, properties=None, attProperties=None, *args, **kwargs):
+    def __init__(self, wxClass, parent, properties=None, attProperties=None, *args, **kwargs):
         self._dregex = {}
         self._lastDataType = str
 
-        super(dTextBoxMixin, self).__init__(preClass, parent,
+        super(dTextBoxMixin, self).__init__(wxClass, parent,
                 properties=properties, attProperties=attProperties, *args,
                 **kwargs)
 

--- a/dabo/ui/dTextBoxMixin.py
+++ b/dabo/ui/dTextBoxMixin.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-import datetime
-import decimal
-import locale
 import re
+import datetime
 import time
-
+import locale
+import decimal
 numericTypes = (int, int, decimal.Decimal, float)
 valueErrors = (ValueError, decimal.InvalidOperation)
 
@@ -15,19 +14,19 @@ decimalPoint = None
 
 import wx
 import wx.lib.masked as masked
-import dabo
-from dabo import dEvents as dEvents
-from dabo import ui as dui
-from dabo.dLocalize import _
 from dabo.lib import dates
-from dabo.lib.utils import ustr
 from dabo.ui import dKeys
-from dabo.ui import makeDynamicProperty
+from dabo.dLocalize import _
+from dabo.lib.utils import ustr
+from dabo import ui as dui
 from dabo.ui.dDataControlMixin import dDataControlMixin
+from dabo.dLocalize import _
+from dabo import dEvents as dEvents
+from dabo.ui import makeDynamicProperty
 
 
 class dTextBoxMixinBase(dDataControlMixin):
-    def __init__(self, wxClass, parent, properties=None, attProperties=None, *args, **kwargs):
+    def __init__(self, preClass, parent, properties=None, attProperties=None, *args, **kwargs):
         global decimalPoint
         if decimalPoint is None:
             decimalPoint = locale.localeconv()["decimal_point"]
@@ -39,9 +38,8 @@ class dTextBoxMixinBase(dDataControlMixin):
         self._inTextLength = False
         self._flushOnLostFocus = True  ## see dabo.ui.dDataControlMixinBase::flushValue()
 
-        super(dTextBoxMixinBase, self).__init__(wxClass, parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initEvents(self):
@@ -472,13 +470,12 @@ class dTextBoxMixinBase(dDataControlMixin):
 
 
 class dTextBoxMixin(dTextBoxMixinBase):
-    def __init__(self, wxClass, parent, properties=None, attProperties=None, *args, **kwargs):
+    def __init__(self, preClass, parent, properties=None, attProperties=None, *args, **kwargs):
         self._dregex = {}
         self._lastDataType = str
 
-        super(dTextBoxMixin, self).__init__(wxClass, parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dTextBoxMixinBase.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
         # Keep passwords, etc., from being written to disk
         if self.PasswordEntry:

--- a/dabo/ui/dTimer.py
+++ b/dabo/ui/dTimer.py
@@ -12,8 +12,7 @@ class dTimer(PM):
     def __init__(self, parent=None, properties=None, *args, **kwargs):
         print(args, kwargs)
         self._baseClass = dTimer
-        super(dTimer, self).__init__(wxClass=None, parent=parent,
-                properties=properties, *args, **kwargs)
+        super(dTimer, self).__init__(preClass=None, parent=parent, properties=properties, *args, **kwargs)
 
 
     def isRunning(self):

--- a/dabo/ui/dTimer.py
+++ b/dabo/ui/dTimer.py
@@ -12,7 +12,7 @@ class dTimer(PM):
     def __init__(self, parent=None, properties=None, *args, **kwargs):
         print(args, kwargs)
         self._baseClass = dTimer
-        super(dTimer, self).__init__(preClass=None, parent=parent,
+        super(dTimer, self).__init__(wxClass=None, parent=parent,
                 properties=properties, *args, **kwargs)
 
 

--- a/dabo/ui/dToggleButton.py
+++ b/dabo/ui/dToggleButton.py
@@ -31,9 +31,9 @@ class dToggleButton(dDataControlMixin, dImageMixin,
         kwargs["BezelWidth"] = bw
         style = self._extractKey((properties, attProperties, kwargs), "style", 0) | wx.BORDER_NONE
         kwargs["style"] = style
-        super(dToggleButton, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dImageMixin.__init__(self)
+        dDataControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
         self.Bind(wx.EVT_BUTTON, self.__onButton)
 
 

--- a/dabo/ui/dToolBar.py
+++ b/dabo/ui/dToolBar.py
@@ -24,7 +24,7 @@ class dToolBar(dControlMixin, wx.ToolBar):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dToolBar
         self._toolbarItemClass = dToolBarItem
-        preClass = wx.PreToolBar
+        preClass = wx.ToolBar
 
         style = self._extractKey((kwargs, properties, attProperties), "style", 0)
         # Note: need to set the TB_TEXT flag, in order for that to be toggleable

--- a/dabo/ui/dToolBar.py
+++ b/dabo/ui/dToolBar.py
@@ -40,9 +40,8 @@ class dToolBar(dControlMixin, wx.ToolBar):
         # Need this to load/convert image files to bitmaps
         self._image = wx.NullImage
 
-        super(dToolBar, self).__init__(preClass, parent=parent,
-                properties=properties, attProperties=attProperties, *args,
-                **kwargs)
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
+                attProperties=attProperties, *args, **kwargs)
 
 
     def _initProperties(self):

--- a/dabo/ui/dToolBar.py
+++ b/dabo/ui/dToolBar.py
@@ -24,7 +24,7 @@ class dToolBar(dControlMixin, wx.ToolBar):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dToolBar
         self._toolbarItemClass = dToolBarItem
-        wxClass = wx.ToolBar
+        preClass = wx.PreToolBar
 
         style = self._extractKey((kwargs, properties, attProperties), "style", 0)
         # Note: need to set the TB_TEXT flag, in order for that to be toggleable
@@ -40,7 +40,7 @@ class dToolBar(dControlMixin, wx.ToolBar):
         # Need this to load/convert image files to bitmaps
         self._image = wx.NullImage
 
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dToolBar.py
+++ b/dabo/ui/dToolBar.py
@@ -24,7 +24,7 @@ class dToolBar(dControlMixin, wx.ToolBar):
     def __init__(self, parent, properties=None, attProperties=None, *args, **kwargs):
         self._baseClass = dToolBar
         self._toolbarItemClass = dToolBarItem
-        preClass = wx.ToolBar
+        wxClass = wx.ToolBar
 
         style = self._extractKey((kwargs, properties, attProperties), "style", 0)
         # Note: need to set the TB_TEXT flag, in order for that to be toggleable
@@ -40,7 +40,7 @@ class dToolBar(dControlMixin, wx.ToolBar):
         # Need this to load/convert image files to bitmaps
         self._image = wx.NullImage
 
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, *args, **kwargs)
 
 

--- a/dabo/ui/dTreeView.py
+++ b/dabo/ui/dTreeView.py
@@ -417,7 +417,7 @@ class dTreeView(dControlMixin, wx.TreeCtrl):
             style = style | wx.TR_LINES_AT_ROOT
 
         preClass = wx.TreeCtrl
-        super(dTreeView, self).__init__(preClass, parent=parent, properties=properties,
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 
 

--- a/dabo/ui/dTreeView.py
+++ b/dabo/ui/dTreeView.py
@@ -416,8 +416,8 @@ class dTreeView(dControlMixin, wx.TreeCtrl):
         if val:
             style = style | wx.TR_LINES_AT_ROOT
 
-        preClass = wx.TreeCtrl
-        dControlMixin.__init__(self, preClass, parent, properties=properties,
+        wxClass = wx.TreeCtrl
+        dControlMixin.__init__(self, wxClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 
 

--- a/dabo/ui/dTreeView.py
+++ b/dabo/ui/dTreeView.py
@@ -415,7 +415,7 @@ class dTreeView(dControlMixin, wx.TreeCtrl):
         if val:
             style = style | wx.TR_LINES_AT_ROOT
 
-        preClass = wx.PreTreeCtrl
+        preClass = wx.TreeCtrl
         dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 

--- a/dabo/ui/dTreeView.py
+++ b/dabo/ui/dTreeView.py
@@ -31,8 +31,7 @@ class dNode(dObject):
         # Add minimal Dabo functionality
         self.afterInit()
 
-    def afterInit(self):
-        pass
+    def afterInit(self): pass
 
 
     def expand(self):
@@ -416,8 +415,8 @@ class dTreeView(dControlMixin, wx.TreeCtrl):
         if val:
             style = style | wx.TR_LINES_AT_ROOT
 
-        wxClass = wx.TreeCtrl
-        dControlMixin.__init__(self, wxClass, parent, properties=properties,
+        preClass = wx.PreTreeCtrl
+        dControlMixin.__init__(self, preClass, parent, properties=properties,
                 attProperties=attProperties, style=style, *args, **kwargs)
 
 

--- a/dabo/ui/test.py
+++ b/dabo/ui/test.py
@@ -39,9 +39,13 @@ class Test(object):
             frame = classRefs[0](None, *args, **kwargs)
             isDialog = (issubclass(classRefs[0], wx.Dialog))
         else:
-            frame = dui.dForm(Name="formTest")
-            panel = frame.addObject(dui.dPanel, Name="panelTest")
-            panel.Sizer = dui.dSizer("Vertical")
+            from dabo.ui.dForm import dForm
+            from dabo.ui.dSizer import dSizer
+            from dabo.ui.dPanel import dPanel
+
+            frame = dForm(Name="formTest")
+            panel = frame.addObject(dPanel, Name="panelTest")
+            panel.Sizer = dSizer("Vertical")
             frame.Sizer.append(panel, 1, "expand")
             frame.testObjects = []
             for class_ in classRefs:

--- a/dabo/ui/test.py
+++ b/dabo/ui/test.py
@@ -30,7 +30,6 @@ from dabo.ui.dSizer import dSizer
 logEvents = ["All", "Idle", "MouseMove"]
 class Test(object):
     def __init__(self):
-        super(Test, self).__init__()
         self.app = dApp()
         self.app.MainFormClass = None
         self.app.setup()
@@ -46,11 +45,6 @@ class Test(object):
             isDialog = (issubclass(classRefs[0], wx.Dialog))
         else:
             frame = dForm(Name="formTest")
-            frame.Show()
-            frame.Layout()
-            self.app.start()
-            return
-            
             panel = frame.addObject(dPanel, Name="panelTest")
             panel.Sizer = dSizer("Vertical")
             frame.Sizer.append(panel, 1, "expand")

--- a/dabo/ui/test.py
+++ b/dabo/ui/test.py
@@ -12,19 +12,14 @@ test of dTextBox.
 If you instead run this test.py as a script, a form will be instantiated with
 all the dControls.
 """
-import os
 import sys
+import os
 import traceback
-
 import wx
-import dabo
 from dabo.dApp import dApp
-from dabo.ui.dEditBox import dEditBox
-from dabo.ui.dForm import dForm
-from dabo.ui.dLabel import dLabel
-from dabo.ui.dPanel import dPanel
-from dabo.ui.dPanel import dScrollPanel
-from dabo.ui.dSizer import dSizer
+import dabo
+# Shorthand
+dui = dabo.ui
 
 # Log all events except the really frequent ones:
 logEvents = ["All", "Idle", "MouseMove"]
@@ -44,9 +39,9 @@ class Test(object):
             frame = classRefs[0](None, *args, **kwargs)
             isDialog = (issubclass(classRefs[0], wx.Dialog))
         else:
-            frame = dForm(Name="formTest")
-            panel = frame.addObject(dPanel, Name="panelTest")
-            panel.Sizer = dSizer("Vertical")
+            frame = dui.dForm(Name="formTest")
+            panel = frame.addObject(dui.dPanel, Name="panelTest")
+            panel.Sizer = dui.dSizer("Vertical")
             frame.Sizer.append(panel, 1, "expand")
             frame.testObjects = []
             for class_ in classRefs:
@@ -80,14 +75,14 @@ class Test(object):
 
     def testAll(self):
         """Create a dForm and populate it with example dWidgets."""
-        frame = dForm(Name="formTestAll")
+        frame = dui.dForm(Name="formTestAll")
         frame.Caption = "Test of all the dControls"
         frame.LogEvents = logEvents
 
-        panel = frame.addObject(dScrollPanel, "panelTest")
+        panel = frame.addObject(dui.dScrollPanel, "panelTest")
         panel.SetScrollbars(10,10,50,50)
         labelWidth = 150
-        vs = dSizer("vertical")
+        vs = dui.dSizer("vertical")
 
         # Get all the python modules in this directory into a list:
         modules = [modname.split(".")[0] for modname in os.listdir(".") if modname[-3:] == ".py"]
@@ -120,27 +115,27 @@ class Test(object):
                     frame.ToolBar = obj
                     break
 
-                bs = dSizer("horizontal")
-                label = dLabel(panel, Alignment="Right", AutoResize=False, Width=labelWidth)
+                bs = dui.dSizer("horizontal")
+                label = dui.dLabel(panel, Alignment="Right", AutoResize=False, Width=labelWidth)
 
                 label.Caption = "%s:" % modname
                 bs.append(label)
 
-                if isinstance(obj, dEditBox):
+                if isinstance(obj, dui.dEditBox):
                     layout = "expand"
                 else:
                     layout = "normal"
 
                 bs.append(obj, layout)
 
-                if isinstance(obj, dEditBox):
+                if isinstance(obj, dui.dEditBox):
                     vs.append(bs, "expand")
                 else:
                     vs.append(bs, "expand")
 
         panel.Sizer = vs
 
-        fs = frame.Sizer = dSizer("vertical")
+        fs = frame.Sizer = dui.dSizer("vertical")
         fs.append(panel, "expand", 1)
         fs.layout()
         self.app.MainForm = frame

--- a/dabo/ui/uiApp.py
+++ b/dabo/ui/uiApp.py
@@ -35,7 +35,7 @@ class SplashScreen(wx.Frame):
     """
     def __init__(self, bitmap=None, maskColor=None, timeout=0):
         style = wx.FRAME_NO_TASKBAR | wx.FRAME_SHAPED | wx.STAY_ON_TOP
-        super(SplashScreen, self).__init__(None, -1, style=style)
+        wx.Frame.__init__(self, None, -1, style=style)
 
         self.SetBackgroundStyle(wx.BG_STYLE_CUSTOM)
         if isinstance(bitmap, str):
@@ -112,7 +112,8 @@ class uiApp(dObject, wx.App):
     def __init__(self, app, callback=None, *args):
         self.dApp = app
         self.callback = callback
-        super(uiApp, self).__init__(*args)
+        wx.App.__init__(self, 0, *args)
+        dObject.__init__(self)
 
         self.Name = _("uiApp")
         # wx has properties for appName and vendorName, so Dabo should update
@@ -182,6 +183,7 @@ class uiApp(dObject, wx.App):
         hnd.setFormatter(fmt)
         log.setLevel(logging.DEBUG)
         log.addHandler(hnd)
+        super(uiApp, self).__init__(*args)
 
 
     def OnInit(self):

--- a/dabo/ui/uiApp.py
+++ b/dabo/ui/uiApp.py
@@ -188,6 +188,13 @@ class uiApp(dObject, wx.App):
 
     def OnInit(self):
         app = self.dApp
+
+        # Set User locale here using wx, rather than in dApp using locale.
+        if dabo.loadUserLocale:
+            # the wx.Locale object will revert its locale changes when its destroyed
+            # So keep a handle on it for the lifespan of the uiApp.
+            self._locale_handle = wx.Locale(wx.LANGUAGE_DEFAULT)
+
         if not self.checkForUpdates():
             return False
         if app.showSplashScreen:
@@ -460,12 +467,14 @@ these automatic updates.""").replace("\n", " ")
             self.dApp.MainForm.raiseEvent(dEvents.Activate)
         except AttributeError:
             self.raiseEvent(dEvents.Activate)
+
         self.MainLoop()
 
 
     def exit(self):
         """Exit the application event loop."""
-        self.Exit()
+        # TODO: figure out what this was intended to do, wx.App has no Exit method, nor does dObject.
+        #self.Exit()
 
 
     def finish(self):
@@ -1155,9 +1164,10 @@ these automatic updates.""").replace("\n", " ")
         Make sure that the MRU items are there and are in the
         correct order.
         """
+        from dabo.ui.dMenuBar import dMenuBar
         cap = menu.Caption
         cleanCap = cleanMenuCaption(cap)
-        topLevel = isinstance(menu.Parent, dabo.ui.dMenuBar)
+        topLevel = isinstance(menu.Parent, dMenuBar)
         mnPrm = self._mruMenuPrompts.get(cleanCap, [])
         if not mnPrm:
             return

--- a/dabo/ui/uiApp.py
+++ b/dabo/ui/uiApp.py
@@ -202,7 +202,7 @@ class uiApp(dObject, wx.App):
                 splash.Update()
         if self.callback is not None:
             wx.CallAfter(self.callback)
-        self.callback = None
+        del self.callback
         return True
 
 

--- a/dabo/ui/uiApp.py
+++ b/dabo/ui/uiApp.py
@@ -423,7 +423,7 @@ these automatic updates.""").replace("\n", " ")
 
 
     def setup(self):
-        wx.SystemOptions.SetOption("mac.textcontrol-use-spell-checker", 1)
+        wx.SystemOptions.SetOptionInt("mac.textcontrol-use-spell-checker", 1)
         frm = self.dApp.MainForm
         if frm is None:
             if self.dApp.MainFormClass is not None:
@@ -465,7 +465,7 @@ these automatic updates.""").replace("\n", " ")
 
     def exit(self):
         """Exit the application event loop."""
-        self.ExitMainLoop()
+        self.Exit()
 
 
     def finish(self):
@@ -530,28 +530,24 @@ these automatic updates.""").replace("\n", " ")
 
     def showCommandWindow(self, context=None):
         """Display a command window for debugging."""
-        from dabo.ui.dShell import dShellForm
         if context is None:
             context = self.ActiveForm
-        dlg = dShellForm(context)
+        dlg = dabo.ui.dShellForm(context)
         dlg.show()
 
 
     def toggleDebugWindow(self, context=None):
         """Display a debug output window."""
-        from dabo.ui.dEditBox import dEditBox
-        from dabo.ui.dForm import dToolForm
-        from dabo.ui.dTimer import dTimer
         if context is None:
             context = self.ActiveForm
-        class DebugWindow(dToolForm):
+        class DebugWindow(dabo.ui.dToolForm):
             def afterInit(self):
                 self.Caption = _("Debug Output")
-                self.out = dEditBox(self, ReadOnly=True)
+                self.out = dabo.ui.dEditBox(self, ReadOnly=True)
                 self.out.bindEvent(dEvents.ContextMenu, self.onContext)
                 self.Sizer.append1x(self.out)
                 self._txtlen = len(self.out.Value)
-                self.tmr = dTimer(self, Interval=500, OnHit=self.onOutValue)
+                self.tmr = dabo.ui.dTimer(self, Interval=500, OnHit=self.onOutValue)
                 self.tmr.start()
             def onContext(self, evt):
                 self.out.Value = ""
@@ -1042,8 +1038,6 @@ these automatic updates.""").replace("\n", " ")
         Run the search on the current control, if it is a text-based control.
         Select the found text in the control.
         """
-        from dabo.ui.dGrid import dGrid
-
         flags = self.findReplaceData.GetFlags()
         findString = self.findReplaceData.GetFindString()
         replaceString = self.findReplaceData.GetReplaceString()
@@ -1086,7 +1080,7 @@ these automatic updates.""").replace("\n", " ")
                     win.SetSelection(pos, pos+len(findString))
                 return ret
 
-            elif isinstance(win, dGrid):
+            elif isinstance(win, dabo.ui.dGrid):
                 return win.findReplace(action, findString, replaceString, downwardSearch,
                         wholeWord, matchCase)
             else:
@@ -1161,10 +1155,9 @@ these automatic updates.""").replace("\n", " ")
         Make sure that the MRU items are there and are in the
         correct order.
         """
-        from dabo.ui.dMenuBar import dMenuBar
         cap = menu.Caption
         cleanCap = cleanMenuCaption(cap)
-        topLevel = isinstance(menu.Parent, dMenuBar)
+        topLevel = isinstance(menu.Parent, dabo.ui.dMenuBar)
         mnPrm = self._mruMenuPrompts.get(cleanCap, [])
         if not mnPrm:
             return

--- a/playground.py
+++ b/playground.py
@@ -1,0 +1,179 @@
+"""
+Author: Samuel Dunn
+Intent: Have a playground with accessible wx.lib.inspection.InspectionTool for
+        triaging issues in dabo.
+"""
+import wx
+from dabo.ui.dMenu import dMenu
+from dabo.ui.dMenuBar import dMenuBar
+from dabo.ui.dMenuItem import dMenuItem
+from dabo.dLocalize import _
+
+class MenuBar(dMenuBar):
+    def _afterInit(self):
+        self.dmenu = self.appendMenu(MyDaboMenu(0, self, MenuID="base_whatever"))
+        self.dmenu2 = self.appendMenu(MyDaboMenu(1, self, MenuID="base_whatever2"))
+        self.emenu = self.appendMenu(EditMenu(self, MenuID="base_edit"))
+        self.vmenu = self.appendMenu(ViewMenu(self, MenuID="base_view"))
+        super(MenuBar, self)._afterInit()
+
+
+
+class EditMenu(dMenu):
+    def _afterInit(self):
+        super(EditMenu, self)._afterInit()
+        app = self.Application
+        self.Caption = _("&Edit")
+
+        iconPath = "themes/tango/16x16"
+
+        self.append(_("&Undo"), HotKey="Ctrl+Z", OnHit=app.onEditUndo,
+                bmp="%s/actions/edit-undo.png" % iconPath,
+                ItemID="edit_undo",
+                help=_("Undo last action"))
+
+        self.append(_("&Redo"), HotKey="Ctrl+Shift+Z", OnHit=app.onEditRedo,
+                bmp="%s/actions/edit-redo.png" % iconPath,
+                ItemID="edit_redo",
+                help=_("Undo last undo"))
+
+        self.appendSeparator()
+
+        self.append(_("Cu&t"), HotKey="Ctrl+X", OnHit=app.onEditCut,
+                bmp="%s/actions/edit-cut.png" % iconPath,
+                ItemID="edit_cut",
+                help=_("Cut selected text"))
+
+        self.append(_("&Copy"), HotKey="Ctrl+C", OnHit=app.onEditCopy,
+                bmp="%s/actions/edit-copy.png" % iconPath,
+                ItemID="edit_copy",
+                help=_("Copy selected text"))
+
+        self.append(_("&Paste"), HotKey="Ctrl+V", OnHit=app.onEditPaste,
+                bmp="%s/actions/edit-paste.png" % iconPath,
+                ItemID="edit_paste",
+                help=_("Paste text from clipboard"))
+
+        self.append(_("Select &All"), HotKey="Ctrl+A", OnHit=app.onEditSelectAll,
+                bmp="%s/actions/edit-select-all.png" % iconPath,
+                ItemID="edit_selectall",
+                help=_("Select all text"))
+
+        self.appendSeparator()
+
+        # By default, the Find and Replace functions use a single dialog. The
+        # commented lines below this enable the plain Find dialog call.
+        self.append(_("&Find / Replace"), HotKey="Ctrl+F", OnHit=app.onEditFind,
+                bmp="%s/actions/edit-find-replace.png" % iconPath,
+                ItemID="edit_findreplace",
+                help=_("Find or Replace text in the active window"))
+
+        self.append(_("Find A&gain"), HotKey="Ctrl+G", OnHit=app.onEditFindAgain, bmp="",
+                ItemID="edit_findagain",
+                help=_("Repeat the last search"))
+
+        self.appendSeparator()
+
+        self.append(_("Pr&eferences"), OnHit=app.onEditPreferences,
+                bmp="%s/categories/preferences-system.png" % iconPath,
+                ItemID="edit_preferences",
+                help=_("Set user preferences"), special="pref" )
+
+
+class ViewMenu(dMenu):
+    def _afterInit(self):
+        super(ViewMenu, self)._afterInit()
+        app = self.Application
+        _ = lambda a: a
+        self.Caption = _("&View")
+
+        self.append(_("Increase Font Size"),
+                HotKey="Ctrl++",
+                ItemID="view_zoomin", OnHit=app.fontZoomIn,
+                help=_("Increase the font size"))
+        self.append(_("Decrease Font Size"),
+                HotKey="Ctrl+-",
+                ItemID="view_zoomout", OnHit=app.fontZoomOut,
+                help=_("Decrease the font size"))
+        self.append(_("Normal Font Size"),
+                HotKey="Ctrl+/",
+                ItemID="view_zoomnormal", OnHit=app.fontZoomNormal,
+                help=_("Set font size to normal"))
+
+        if app.ShowSizerLinesMenu:
+            self.appendSeparator()
+            self.Parent.sizerLinesMenuItem = self.append(_("Show/Hide Sizer &Lines"), HotKey="Ctrl+L",
+                    OnHit=app.onShowSizerLines, menutype="check",
+                    ItemID="view_showsizerlines",
+                    help=_("Cool sizer visualizing feature; check it out!"))
+
+
+class MyDaboMenu(dMenu):
+    def __init__(self, pos, *args, **kwargs):
+        self.__pos = pos
+        super(MyDaboMenu, self).__init__(*args, **kwargs)
+
+    def _afterInit(self):
+        super(MyDaboMenu, self)._afterInit()
+
+        app = self.Application
+
+        # Set caption:
+        self.Caption = f"d&Menu{self.__pos}"
+
+        #dmi = dMenuItem(self, Caption="dMenuItem")
+        #self.appendItem(dmi)
+
+        # Try using daboMenu.append ( ... ) like dBaseMenuBar menus do.
+        self.appendSeparator()
+        self.append("directly appended", help="help text")
+        self.append('has OnHit', help = "help text 2", OnHit=lambda *args, **kwargs: print(f"dMenuItem OnHit: args {args}, kwargs {kwargs}"))
+        self.append("has bmp", help="has bmp", bmp="themes/tango/16x16/apps/utilities-terminal.png")
+        self.append("no help", bmp="themes/tango/16x16/apps/system-search.png")
+        self.append("checkbox item", help="this item has a checkbox", menutype="check")
+        self.append("has id", ItemID="menu_hasid")
+        self.append("has hotkey", HotKey="Ctrl+-")
+        self.appendSeparator()
+
+
+
+        self.append(_("Close Windo&w"), HotKey="Ctrl+W", OnHit=app.onWinClose,
+                ItemID="file_close",
+                help=_("Close the current window"))
+
+        self.append(_("&Quit"), HotKey="Ctrl+Q", id=wx.ID_EXIT, OnHit=app.onFileExit,
+                bmp="themes/tango/16x16/actions/system-log-out.png",
+                ItemID="file_quit",
+                help=_("Exit the application"))
+
+def main():
+    import dabo
+    from dabo.ui.dForm import dForm
+    from wx.lib.inspection import InspectionTool
+
+    app = dabo.dApp()
+    app.MainFormClass = None
+    app.setup()
+
+    # Select menu creation style here. The latter line will allow the user to call
+    # playground.setupTestMenuBar(form_object) after mainloop construction.
+
+    #form = dForm(None, MenuBarClass=MenuBar)
+    form = dForm(None, MenuBarClass=None, ShowMenuBar=False)
+
+    form.show()
+
+    InspectionTool().Show(True)
+
+    app.start()
+
+def setupTestMenuBar(frame):
+    from dabo.ui.dMenu import dMenu
+    from dabo.ui.dMenuItem import dMenuItem
+
+    mb = MenuBar()
+
+    frame.SetMenuBar(mb)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This set of changes migrates dabo to be phoenix compatible, though there are still a plethora of python-specific issues, most of which are passing module objects to `isinstance` function calls.

This set of changes fixes #29, #16, and the segmentation fault indicated in #30.

The most prominent problems I encountered when I started on this branch stemmed from a misuse of python's `super` function, which led to a lot of multi-inheritance objects only being partially constructed. So I reverted back to a more stable commit and worked from there. 

As such this set of changes still uses wxWidgets' 2-stage-creation paradigm, as that was the path of least changes. A synopsis of changes is as follows: 
-  all `wx.Pre(.*)` symbols have been converted to `wx.\1`, (e.g. wx.PreFrame -> wx.Frame) (82d4729)
- Check if a wx.MenuItem can support a bitmap assignment before blindly assigning a bitmap. (de421c8)
- removed menu items will now be removed from the wx.MenuBar at the C++ level as well, preventing segmentation faults that occurred as a byproduct  of having a menu. (80c61c0)
- A dummy menuitem is no longer appended to a menubar. I saw no real benefit to this block of code. Though I will not oppose reverting this particular change. (80c61c0)
- Made setting user-locale more wx friendly. This may have some drawbacks, see the commit message. (c5ca726)
- The addition of `playground.py`, which is a simple script that launches an empty dForm along with the `wx.lib.inspection.InspectionTool`, which allows you to play around and inspect widgets at runtime. It was suggested that this be included for dabo developers to work with, though I am not opposed to its removal either. (794bda1)

ui modules known to work when invoked as __main__:
- dFormMain.py
- dCheckBox.py
- dTextBox.py