### PR TITLE
[WIP] Fixes to dabo.ui.dGrid

### DIFF
--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1544,7 +1544,10 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
             ht = rect.height+2
             if self._minHeight:
                 ht = max(self._minHeight, ht)
-            self._control.SetDimensions(rect.x, rect.y, wd, ht, wx.SIZE_ALLOW_MINUS_ONE)
+
+            self._control.SetSize(wd, ht)
+            self._control.SetPosition(wx.Point(rect.x, rect.y))
+            #self._control.SetDimensions(rect.x, rect.y, wd, ht, wx.SIZE_ALLOW_MINUS_ONE)
 
         def PaintBackground(self, dc, rect, attr):
             """

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1488,6 +1488,11 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
         _minWidth = None
         _minHeight = None
 
+        def __init__(self, *args, **kwargs):
+            """
+            """
+            wx.grid.GridCellEditor.__init__(self, *args, **kwargs)
+
         def Create(self, parent, id, evtHandler):
             """
             Called to create the control, which must derive from wx.Control.
@@ -1541,7 +1546,7 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
                 ht = max(self._minHeight, ht)
             self._control.SetDimensions(rect.x, rect.y, wd, ht, wx.SIZE_ALLOW_MINUS_ONE)
 
-        def PaintBackground(self, rect, attr):
+        def PaintBackground(self, dc, rect, attr):
             """
             Draws the part of the cell not occupied by the edit control.  The
             base  class version just fills it with background colour from the
@@ -1562,7 +1567,7 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
             self._control.Value = self.startValue
             self._control.setFocus()
 
-        def EndEdit(self, row, col, grid):
+        def EndEdit(self, row, col, grid, oldval):
             """
             Complete the editing of the current cell. Returns True if the value
             has changed.  If necessary, the control may be destroyed.
@@ -1576,7 +1581,12 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
                 changed = True
                 grid.GetTable().SetValue(row, col, val, _fromGridEditor=True)
             self.startValue = None
-            return changed
+            return val if changed else None
+
+        def ApplyEdit(self, row, col, grid):
+            """
+            """
+            pass
 
         def Reset(self):
             """

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1585,6 +1585,12 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
 
         def ApplyEdit(self, row, col, grid):
             """
+            Effectively save the changes in the grid.
+
+            This function should save the value of the control in the grid.
+            It is called only after EndEdit returns a value indicating change..
+
+            *Must Override*
             """
             pass
 

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1504,6 +1504,20 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
             if evtHandler:
                 self._control.PushEventHandler(evtHandler)
 
+        def GetControl(self):
+            """
+            Return the internal instance of the control class.
+
+            *Must Override*
+
+            Because the control instance is never passed down into wxWidgets, it won't know how to pass the control
+            back up, and calls to GetControl will therefore return None.
+
+            :return: the instance of the control class.
+
+            """
+            return self._control
+
         def _onKeyDown(self, evt):
             ed = evt.EventData
             key, mod, shift = (ed["keyCode"], ed["hasModifiers"],

--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1504,20 +1504,6 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
             if evtHandler:
                 self._control.PushEventHandler(evtHandler)
 
-        def GetControl(self):
-            """
-            Return the internal instance of the control class.
-
-            *Must Override*
-
-            Because the control instance is never passed down into wxWidgets, it won't know how to pass the control
-            back up, and calls to GetControl will therefore return None.
-
-            :return: the instance of the control class.
-
-            """
-            return self._control
-
         def _onKeyDown(self, evt):
             ed = evt.EventData
             key, mod, shift = (ed["keyCode"], ed["hasModifiers"],


### PR DESCRIPTION
# Various fixes to stabilize the dGrid class.

## Changes included are:
- Correct misuse of GridCellAttrs by reducing calls to `Clone`, Attrs, Renderers, and Editors are reference counted (poorly, in my opinion) at the wxWidgets level, and by not managing calls to `IncRef` and `DecRef` on them when expected (which, again, in my opinion is not always clear) it will lead to objects being prematurely freed, or not freed when expected. (Various seg faults + the "GetEventHandler() == this' wx assertion) (e0f72cd).  If you'd like to maintain use of Clone, you'll want to look into calling the correct wxReferenceCounter methods. (I found it overall easier to just clone less)
- Correct mismatched argspecs between a `CustomEditor` and `wx.grid.GridCellEditor` virtual methods.  These would throw a python exception on invocation (c++ side), which would then be muted by the translation back to c++ and a provide a null value where it was not expected. (af2acba)
- Add a __init__ method to the CustomEditors, this seems to resolve an issue where SIP would not find the custom editors `Create` method (leading to no Control within the Editor) (af2acba)
- Silence a deprecation warning (89e2d65)


## Other observed issues:
I'd like to address these before finalizing this PR
- Custom Editors lose properties after their first use
- Some other segfaults are lurking (haven't tracked down the issue yet)