### PR TITLE
more dGrid changes

### DIFF
--- a/dabo/ui/__init__.py
+++ b/dabo/ui/__init__.py
@@ -1544,7 +1544,10 @@ def makeGridEditor(controlClass, minWidth=None, minHeight=None, **controlProps):
             ht = rect.height+2
             if self._minHeight:
                 ht = max(self._minHeight, ht)
-            self._control.SetDimensions(rect.x, rect.y, wd, ht, wx.SIZE_ALLOW_MINUS_ONE)
+
+            self._control.SetSize(wd, ht)
+            self._control.SetPosition(wx.Point(rect.x, rect.y))
+            #self._control.SetDimensions(rect.x, rect.y, wd, ht, wx.SIZE_ALLOW_MINUS_ONE)
 
         def PaintBackground(self, dc, rect, attr):
             """

--- a/dabo/ui/dGrid.py
+++ b/dabo/ui/dGrid.py
@@ -107,9 +107,10 @@ class dGridDataTable(wx.grid.GridTableBase):
 
         # Prevents overwriting when a long cell has None in the one next to it.
         attr.SetOverflow(False)
-        #self.__cachedAttrs[(row, col)] = (attr, time.time())
+
         if do_incref:
             attr.IncRef()
+
         return attr
 
 
@@ -1580,7 +1581,6 @@ class dColumn(wx._core.Object, dPemMixin):
             raise ValueError("SortKey must be callable.")
 
 
-
     BackColor = property(_getBackColor, _setBackColor, None,
             _("Color for the background of each cell in the column."))
 
@@ -2031,7 +2031,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
         self.Bind(wx.grid.EVT_GRID_RANGE_SELECT, self.__onWxGridRangeSelect)
         self.Bind(wx.EVT_SCROLLWIN, self.__onWxScrollWin)
 
-        # Testing bool cell renderer/editor single-click-toggle:`
+        # Testing bool cell renderer/editor single-click-toggle:
         self.Bind(wx.grid.EVT_GRID_CELL_LEFT_CLICK, self.__onGridCellLeftClick_toggleCB)
 
         gridWindow = self.GetGridWindow()
@@ -2060,7 +2060,6 @@ class dGrid(dControlMixin, wx.grid.Grid):
 
         self.bindEvent(dEvents.Create, self._onCreate)
         self.bindEvent(dEvents.Destroy, self._onDestroy)
-
 
         super(dGrid, self)._initEvents()
 
@@ -3086,7 +3085,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
                 try:
                     sortList.sort(key=sortKey, reverse=(sortOrder == "DESC"))
                 except TypeError:
-                    s = "Unable to sort this column. Conflicting, or unknown, data types within the column make it impossible to sort implicitly."\
+                    s = "Unable to sort this column. Conflicting, or unknown, data types within the column make it impossible to sort implicitly. "\
                         "Please supply a sort key method to the column, via the SortKey property, to delegate sort behavior to."
                     if colObj.SortKey is not None:
                         # the preceding exception information will be useful for developers to debug their SortKey method
@@ -4389,6 +4388,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
         self.SaveEditControlValue()
         self.HideCellEditControl()
         evt.Skip()
+
 
     def __onWxGridCellChange(self, evt):
         self.raiseEvent(dEvents.GridCellEdited, evt)

--- a/dabo/ui/dGrid.py
+++ b/dabo/ui/dGrid.py
@@ -98,15 +98,18 @@ class dGridDataTable(wx.grid.GridTableBase):
             attr.SetRenderer(rnd)
             if r in (dcol.floatRendererClass, dcol.decimalRendererClass):
                 rnd.SetPrecision(dcol.Precision)
-
+        do_incref = True
         # Now check for alternate row coloration
         if self.alternateRowColoring:
+            do_incref = False
+            attr = attr.Clone()
             attr.SetBackgroundColour((self.rowColorEven, self.rowColorOdd)[row % 2])
 
         # Prevents overwriting when a long cell has None in the one next to it.
         attr.SetOverflow(False)
-        self.__cachedAttrs[(row, col)] = (attr, time.time())
-        attr.IncRef()
+        #self.__cachedAttrs[(row, col)] = (attr, time.time())
+        if do_incref:
+            attr.IncRef()
         return attr
 
 
@@ -2012,7 +2015,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
         self.Bind(wx.grid.EVT_GRID_RANGE_SELECT, self.__onWxGridRangeSelect)
         self.Bind(wx.EVT_SCROLLWIN, self.__onWxScrollWin)
 
-        # Testing bool cell renderer/editor single-click-toggle:
+        # Testing bool cell renderer/editor single-click-toggle:`
         self.Bind(wx.grid.EVT_GRID_CELL_LEFT_CLICK, self.__onGridCellLeftClick_toggleCB)
 
         gridWindow = self.GetGridWindow()
@@ -2041,6 +2044,7 @@ class dGrid(dControlMixin, wx.grid.Grid):
 
         self.bindEvent(dEvents.Create, self._onCreate)
         self.bindEvent(dEvents.Destroy, self._onDestroy)
+
 
         super(dGrid, self)._initEvents()
 
@@ -5531,6 +5535,7 @@ class _dGrid_test(dGrid):
         self.Width = 360
         self.Height = 150
         self.Editable = False
+        #self.AlternateRowColoring = True
         #self.Sortable = False
         #self.Searchable = False
 


### PR DESCRIPTION
This PR contains 3 changes

- Editor properties are reapplied when its shown, hopefully preserving intended look and feel with out discarding relevant changes. I consulted @EdLeafe  about this a while ago and he didn't present a better solution at the time.

- a quick fix to correct row shading behavior should `dGrid.AlternateRowColoring` be set. Its an unideal fix, relying on further GridCellAttr cloning, but I don't think it'll present further complications. 🤷‍♂ 

- It also adds a property to dColumns to allow clients to specify sorting behavior via a sort key method. This will shift the burden of sorting to programmers who know the contents of the column, rather than library code that can only guess. 
Should sorting fail, a new type error is raised to inform users how to resolve the issue with out seeking the dabo dev team for assistance. 

